### PR TITLE
Task/eparker71/tlt 2559/sort available roles

### DIFF
--- a/manage_people/static/manage_people/js/results_list.js
+++ b/manage_people/static/manage_people/js/results_list.js
@@ -1,15 +1,23 @@
+/*
+* JS for the Manage People - Add People form
+* */
+$(document).ready(function () {
 
-$(document).ready(function(){
+    var usersFound = $('.user-select-checkbox', '#add_users_form').length;
 
-    var usersFound = $('.user-select-checkbox').length;
-
-    if (usersFound){
+    /*
+    * Setup the form based on the number of users found. If there are no users, unhide the
+    * users-not-found text. If one user was found, they will have a default role selection of
+    * guest, so we enable the submit button. If multiple users were found, they will also have a
+    * default role selection of guest, but the user will need to select which ones to add. The submit
+    * button will be disabled until the user selects one or more users. 
+    * */
+    if (usersFound) {
         $('.users-found').removeClass('hidden');
-        if ( usersFound == 1 ) {
-            $('#add_users_form').find('select').removeClass('disabled');
+        if (usersFound == 1) {
             $('#user_create_button').removeClass('btn-disabled').addClass('btn-submit');
         }
-        else if (usersFound > 1){
+        else if (usersFound > 1) {
             $('#user_create_button').removeClass('btn-submit').addClass('btn-disabled');
         }
     } else {
@@ -17,52 +25,60 @@ $(document).ready(function(){
         $('.users-not-found').removeClass('hidden');
     }
 
-    $('.user-select-checkbox').click(function(){
+    /*
+    * In the case where the user has multiple ids to add. Enable or disable the
+    * submit button based how many checkboxes have been selected. If none are
+    * selected, disable the button. If one or more are selected enable the button.
+    * */
+    $('.user-select-checkbox', '#add_users_form').click(function () {
         toggleAlert();
-
-        if( $('.user-select-checkbox:checked').size() > 0 ){
-            if ($('#user_create_button').hasClass('btn-disabled')){
-                $('#user_create_button').removeClass('btn-disabled').addClass('btn-submit');
-            }
+        if ($('.user-select-checkbox:checked').size() > 0 && $('#user_create_button').hasClass('btn-disabled')) {
+            $('#user_create_button').removeClass('btn-disabled').addClass('btn-submit');
         }
-        else {
-            if ($('#user_create_button').hasClass('btn-submit')) {
-                $('#user_create_button').removeClass('btn-submit').addClass('btn-disabled');
-            }
+        else if ($('#user_create_button').hasClass('btn-submit')) {
+            $('#user_create_button').removeClass('btn-submit').addClass('btn-disabled');
         }
+        return false;
     });
 
-    $('#user_create_button').click(function(e){
+    /*
+    * When the user clicks submit we need to build the list of the users that are going to be added.
+    * */
+    $('#user_create_button').click(function (e) {
         toggleAlert();
         $('#user_create_button').button('loading');
-
         var usersToAdd = {};
-        $('.user-select-checkbox:checked').each(function(){
+        $('.user-select-checkbox:checked', '#add_users_form').each(function () {
             usersToAdd[$(this).val()] = $(this).closest('li').find('select').val();
         });
-        
         // Update hidden input element with users to add
-        $('#add_users_form input[name="users_to_add"]').val(JSON.stringify(usersToAdd));
+        $('#users_to_add').val(JSON.stringify(usersToAdd));
+        return false;
     });
 
-    $('#form-show').click(function(e){
-        //maintain the cancel link hidden
+    /*
+    * Show the form containing any extra id's the user has that can be added to the course
+    * */
+    $('#form-show').click(function (e) {
         $('#cancel_add_to_course').addClass('hidden');
-        //hide the show btn
         $(this).addClass('hidden');
-        //show the form with extra available IDs
         $('form').removeClass('hidden');
+        return false;
     });
 
-    $('#form-hide').click(function(e){
-        //hide the form
+    /*
+    * Hide the form containing any extra id's the user has that can be added to the course
+    * */
+    $('#form-hide').click(function (e) {
         $('form').addClass('hidden');
-        //bring back the button to show the form
         $('#form-show').removeClass('hidden');
+        return false;
     });
 
+    /*
+    * Toggle alert messages in the case of errors
+    * */
     function toggleAlert(errorName, state, errorElements) {
-
         if (typeof errorName == 'undefined') {
             $('.alert-lti').toggleClass('hidden', true);
             $('.alert-lti li').toggleClass('hidden', true);
@@ -70,9 +86,10 @@ $(document).ready(function(){
         } else {
             var $alert = $('.alert-lti').toggleClass('hidden', state);
             $alert.find('li.' + errorName).toggleClass('hidden', state);
-            $(errorElements).each(function(index, $el){
+            $(errorElements).each(function (index, $el) {
                 $el.toggleClass('has-error', state);
             });
         }
+        return false;
     }
 });

--- a/manage_people/static/manage_people/js/results_list.js
+++ b/manage_people/static/manage_people/js/results_list.js
@@ -10,7 +10,7 @@ $(document).ready(function () {
     * users-not-found text. If one user was found, they will have a default role selection of
     * guest, so we enable the submit button. If multiple users were found, they will also have a
     * default role selection of guest, but the user will need to select which ones to add. The submit
-    * button will be disabled until the user selects one or more users. 
+    * button will be disabled until the user selects one or more users.
     * */
     if (usersFound) {
         $('.users-found').removeClass('hidden');
@@ -38,7 +38,6 @@ $(document).ready(function () {
         else if ($('#user_create_button').hasClass('btn-submit')) {
             $('#user_create_button').removeClass('btn-submit').addClass('btn-disabled');
         }
-        return false;
     });
 
     /*
@@ -53,7 +52,6 @@ $(document).ready(function () {
         });
         // Update hidden input element with users to add
         $('#users_to_add').val(JSON.stringify(usersToAdd));
-        return false;
     });
 
     /*
@@ -63,7 +61,6 @@ $(document).ready(function () {
         $('#cancel_add_to_course').addClass('hidden');
         $(this).addClass('hidden');
         $('form').removeClass('hidden');
-        return false;
     });
 
     /*
@@ -72,7 +69,6 @@ $(document).ready(function () {
     $('#form-hide').click(function (e) {
         $('form').addClass('hidden');
         $('#form-show').removeClass('hidden');
-        return false;
     });
 
     /*
@@ -90,6 +86,5 @@ $(document).ready(function () {
                 $el.toggleClass('has-error', state);
             });
         }
-        return false;
     }
 });

--- a/manage_people/static/manage_people/js/results_list.js
+++ b/manage_people/static/manage_people/js/results_list.js
@@ -1,86 +1,49 @@
+
 $(document).ready(function(){
 
-    var usersFound = $('#matching-records input[type="checkbox"]').length;
+    var usersFound = $('.user-select-checkbox').length;
+
     if (usersFound){
         $('.users-found').removeClass('hidden');
-        //make the dropdown enable if the the search only returns one result
         if ( usersFound == 1 ) {
             $('#add_users_form').find('select').removeClass('disabled');
+            $('#user_create_button').removeClass('btn-disabled').addClass('btn-submit');
+        }
+        else if (usersFound > 1){
+            $('#user_create_button').removeClass('btn-submit').addClass('btn-disabled');
         }
     } else {
+        $('#user_create_button').removeClass('btn-submit').addClass('btn-disabled');
         $('.users-not-found').removeClass('hidden');
     }
-    
 
-    $('#matching-records input[type="checkbox"]').click(function(){
+    $('.user-select-checkbox').click(function(){
         toggleAlert();
-        //make dropdown available to use after the user checks the email
-        var $select = $(this).closest('li').find('select');
-        if ($(this).prop('checked')) {
-            $select.removeClass('disabled');
-            //if user checks an ID(checkbox) then the button becomes disabled and let the select menu choice make it available again
-            $('#user_create_button').removeClass('btn-submit').addClass('btn-disabled');
-        } else {
-            $select.val($select.find('option:first').val());
-            $select.addClass('disabled');
-            //remove disabled class if the user 
-            $('#user_create_button').removeClass('btn-disabled').addClass('btn-submit');
+
+        if( $('.user-select-checkbox:checked').size() > 0 ){
+            if ($('#user_create_button').hasClass('btn-disabled')){
+                $('#user_create_button').removeClass('btn-disabled').addClass('btn-submit');
+            }
         }
-        //if after checking/unchecking ids, set the submit button to disabled if all boxes are left unchecked
-        checkChecked('add_users_form');
-    });
-
-
-    //clears out dropdown errors
-    $('#matching-records select').change(function(){
-        var hasCheck = $('#matching-records input:checked').length > 0;
-        var rolesSelected = true;
-        var missingRoleSelection = [];
-        $('#matching-records input:checked').each(function(){
-            var $li = $(this).closest('li');
-            if ($li.find('select').val()==="choose") {
-                rolesSelected = rolesSelected && false;
-                missingRoleSelection.push($li);
-                //if user hasn't picked a role then disable the button
+        else {
+            if ($('#user_create_button').hasClass('btn-submit')) {
                 $('#user_create_button').removeClass('btn-submit').addClass('btn-disabled');
             }
-
-        });
-
-
-
-        if (hasCheck && rolesSelected) {
-            $('#user_create_button').removeClass('btn-disabled').addClass('btn-submit');
-        }else{
-            $('#user_create_button').removeClass('btn-submit').addClass('btn-disabled');
-        }
-
-        if ($(this).val() != $(this).find('option:first').val()) {
-            
-            toggleAlert();
-            checkChecked('add_users_form');
-        }
-
-        //if the user resets the select menu to 'choose role' then disabled the button
-        if ($(this).val() === "choose"){
-            $('#user_create_button').removeClass('btn-submit').addClass('btn-disabled');
         }
     });
 
     $('#user_create_button').click(function(e){
-       
         toggleAlert();
         $('#user_create_button').button('loading');
 
         var usersToAdd = {};
-        $('#matching-records input:checked').each(function(){
+        $('.user-select-checkbox:checked').each(function(){
             usersToAdd[$(this).val()] = $(this).closest('li').find('select').val();
         });
         
         // Update hidden input element with users to add
         $('#add_users_form input[name="users_to_add"]').val(JSON.stringify(usersToAdd));
     });
-    
 
     $('#form-show').click(function(e){
         //maintain the cancel link hidden
@@ -98,34 +61,8 @@ $(document).ready(function(){
         $('#form-show').removeClass('hidden');
     });
 
-    //looks for any selected checkboxes and any selected roles to enable/disable button
-    function checkChecked(formname) {
-        var anyBoxesChecked = false;
-        var noRoleSelected = false;
-        var $dd; 
-        $('#' + formname + ' input[type="checkbox"]').each(function() {
-            if ($(this).is(":checked")) {
-                $dd = $(this).parent().find('select');
-                anyBoxesChecked = true;
-                //keeps a check for dropdowns without selection
-                if ( $dd.val() == "choose" ){
-                    noRoleSelected = true;
-                }
-            }
-        });
-
-        //if user had previously had chosen an email/HUID and role, but then chooses another id and no role while 
-        //unchecking the first id with role then make sure to keep the button disabled
-        if ( anyBoxesChecked && noRoleSelected ){
-            $('#user_create_button').removeClass('btn-submit').addClass('btn-disabled');
-        }else if (anyBoxesChecked == false) {
-        //when all checkboxes are unchecked then keep the btn disabled
-            $('#user_create_button').removeClass('btn-submit').addClass('btn-disabled');
-        } 
-    }
-
     function toggleAlert(errorName, state, errorElements) {
-        
+
         if (typeof errorName == 'undefined') {
             $('.alert-lti').toggleClass('hidden', true);
             $('.alert-lti li').toggleClass('hidden', true);

--- a/manage_people/static/manage_people/js/results_list.js
+++ b/manage_people/static/manage_people/js/results_list.js
@@ -32,8 +32,10 @@ $(document).ready(function () {
     * */
     $('.user-select-checkbox', '#add_users_form').click(function () {
         toggleAlert();
-        if ($('.user-select-checkbox:checked').size() > 0 && $('#user_create_button').hasClass('btn-disabled')) {
-            $('#user_create_button').removeClass('btn-disabled').addClass('btn-submit');
+        if ($('.user-select-checkbox:checked').size() > 0) {
+            if( $('#user_create_button').hasClass('btn-disabled')) {
+                $('#user_create_button').removeClass('btn-disabled').addClass('btn-submit');
+            }
         }
         else if ($('#user_create_button').hasClass('btn-submit')) {
             $('#user_create_button').removeClass('btn-submit').addClass('btn-disabled');

--- a/manage_people/templates/manage_people/results_list.html
+++ b/manage_people/templates/manage_people/results_list.html
@@ -93,7 +93,7 @@
 
     <form id="add_users_form" class="form {% if enrolled_roles_by_id|length != 0 and unique_results %} hidden {% endif %}" method="post" action="{% url 'manage_people:add_users' %}" role="form">{% csrf_token %}
         <input type="hidden" name="user_search_term" value="{{ user_search_term }}" >
-        <input type="hidden" name="users_to_add" value="{}" >
+        <input type="hidden" id="users_to_add" name="users_to_add" value="{}" >
 
         {% if unique_results %}
             <fieldset id="matching-records" class="users-found hidden">

--- a/manage_people/templates/manage_people/results_list.html
+++ b/manage_people/templates/manage_people/results_list.html
@@ -14,6 +14,7 @@
 {% endblock breadcrumbs %}
 
 {% block content %}
+
     <div class="infoBlock-error alert-lti hidden">
         <ul>
             <li class="email hidden"><strong>You must choose at least one directory record</strong></li>
@@ -60,17 +61,22 @@
     {% if enrolled_roles_by_id|length != 0 %}
         <ul id="existing_enrollments_list" class="list-with-floats">
           {% for _, person in results.items %}
+
             {% for univ_id, roles in enrolled_roles_by_id.items %}
-              {% for role_canvas_name in roles %}
-                <li data-univ-id="{{ univ_id }}" data-role="{{ role_canvas_name }}">
-                  {{ person.email_address }} <span class="label">{{ person.badge_label_name }}</span>
-                  <span class="float-right text-strong">
-                    Enrolled as a {{ role_canvas_name|get_role_display_name }}
-                  </span>
-                </li>
-              {% endfor %}
+                {% if person.univ_id == univ_id %}
+                  {% for role_canvas_name in roles %}
+                    <li data-univ-id="{{ univ_id }}" data-role="{{ role_canvas_name }}">
+                      {{ person.email_address }} <span class="label">{{ person.badge_label_name }}</span>
+                      <span class="float-right text-strong">
+                        Enrolled as a {{ role_canvas_name|get_role_display_name }}
+                      </span>
+                    </li>
+                  {% endfor %}
+                {% endif %}
             {% endfor %}
+
           {% endfor %}
+
         </ul>
 
         {% if unique_results %}
@@ -95,10 +101,12 @@
                 <ul class="list-with-floats">
                     {% for key, result in unique_results.items %}
                         <li>
-                            {% if results|length == 1 %}
-                                <input id="record-{{ forloop.counter }}" type="checkbox" class="sr-only" name="add_user_id_{{ forloop.counter }}" value="{{ result.univ_id }}" checked>
+                            {% if unique_results|length == 1 %}
+                                <input id="record-{{ forloop.counter }}" type="checkbox" class="sr-only user-select-checkbox"
+                                       name="add_user_id_{{ forloop.counter }}" value="{{ result.univ_id }}" checked>
                             {% else %}
-                                <input id="record-{{ forloop.counter }}" type="checkbox" name="add_user_id_{{ forloop.counter }}" value="{{ result.univ_id }}">
+                                <input id="record-{{ forloop.counter }}" type="checkbox" class="user-select-checkbox"
+                                       name="add_user_id_{{ forloop.counter }}" value="{{ result.univ_id }}">
                             {% endif %}
                             <label class="plain" for="record-{{ forloop.counter }}">
                                 {{ result.name_first }} {{ result.name_last }} ({{ result.email_address }})
@@ -108,12 +116,11 @@
                             <div class="float-right">
                                 <label for="select-role-{{ forloop.counter }}"><span class="sr-only">Add as a:</span></label>
                                 {# todo: Consider user id data directly into id param; need to check where id is used in current code #}
-                                <select id="select-role-{{ forloop.counter }}" class="disabled" name="select_role_id_{{ forloop.counter }}" data-selenium-user-id="{{ result.univ_id }}">
-                                    <option value="choose">Choose role</option>
+                                <select id="select-role-{{ forloop.counter }}" name="select_role_id_{{ forloop.counter }}" data-selenium-user-id="{{ result.univ_id }}">
                                     {% for user_role in available_roles %}
                                         {% if result.badge_label_name != 'XID' or user_role.xid_allowed %}
                                             <option value={{ user_role.role_id }}
-                                                    data-role="{{ user_role.role_id }}">
+                                                    data-role="{{ user_role.role_id }}" {%if user_role.role_name == "Guest" %} selected="selected"{% endif %}>
                                               {{ user_role.role_name|tf_to_ta_filter }}
                                             </option>
                                         {% endif %}
@@ -131,7 +138,7 @@
                 <a id="form-hide" href="#" class="btn-toggle float-left"><i class="fa fa-toggle-up"></i> Hide Additional IDs</a>
             {% endif %}
             <a id="cancel_add_to_course" href="{% url 'manage_people:user_form' %}" class="users-found hidden">Cancel</a>
-            <button id="user_create_button" class="btn-disabled users-found hidden" type="submit" data-loading-text="Adding to course...">Add to course</button>
+            <button id="user_create_button" class="btn-submit users-found" type="submit" data-loading-text="Adding to course...">Add to course</button>
             <a id="find_another_user" href="{% url 'manage_people:find_user' %}" class="users-not-found hidden">Search for a different person</a>
             <a id="back_to_user_form" href="{% url 'manage_people:user_form' %}" class="users-not-found hidden">Go back to Manage People</a>
         </div>


### PR DESCRIPTION
The original story called for sorting the roles alphabetically on the add people form. The roles were already sorted so that part was easy. The next part called for setting the default role as guest. This involved removing the current default which was a static option with text saying "Choose Role" and modifying the html template and JS to function correctly as functionality was tied to the "Choose Role" option. 

Also, I discovered a small bug in the template that only appeared when a user had multiple id's and one of those id's was already added to the course. When you tried to add the user a second time, you see a list of all the roles they have as though they were all added to the course already. My fix makes it so you see the roles that are currently enrolled at the top with the additional roles that can be added at the bottom. 