### PR TITLE
TLT-2747 - manage sections - works for any roles

### DIFF
--- a/canvas_manage_course/requirements/base.txt
+++ b/canvas_manage_course/requirements/base.txt
@@ -13,5 +13,5 @@ requests==2.9.1
 
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.8.4#egg=canvas-python-sdk==0.8.4
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.5#egg=django-auth-lti==1.2.5
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.10.34#egg=django-icommons-common[async]==1.10.34
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.12#egg=django-icommons-common[async]==1.12
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v1.0#egg=django-icommons-ui==1.0

--- a/canvas_manage_course/requirements/local.txt
+++ b/canvas_manage_course/requirements/local.txt
@@ -5,7 +5,7 @@
 # below are requirements specific to the local environment
 
 ddt==1.0.1
-django-debug-toolbar==1.4
+django-debug-toolbar==1.5
 django-sslserver==0.19
 flake8==2.5.4
 mock==2.0.0

--- a/manage_sections/migrations/0001_initial.py
+++ b/manage_sections/migrations/0001_initial.py
@@ -18,7 +18,7 @@ LTI_PERMISSIONS_DATA = [
     ('manage_sections', '*', 'Librarian', True),
     ('manage_sections', '*', 'ObserverEnrollment', False),
     ('manage_sections', '*', 'SchoolLiaison', True),
-    ('manage_sections', '*', 'Shopper', False),
+    ('manage_sections', '*', 'Prospective Enrollee', False),
     ('manage_sections', '*', 'StudentEnrollment', False),
     ('manage_sections', '*', 'TaEnrollment', True),
     ('manage_sections', '*', 'TeacherEnrollment', True),

--- a/manage_sections/templates/manage_sections/_enrollments_list_by_name.html
+++ b/manage_sections/templates/manage_sections/_enrollments_list_by_name.html
@@ -28,18 +28,28 @@
                 data-course_section_id="{{ enrollee.course_section_id }}" 
                 data-sis_course_id="{{enrollee.sis_course_id}}"
                 data-user_id="{{enrollee.user.id}}" 
-                data-enrollment_role="{{enrollee.role}}" 
-                data-section="{{section_id}}" 
+                data-enrollment_role="{{enrollee.role}}"
+                data-enrollment_role_id="{{enrollee.role_id}}"
+                data-enrollment_role_label="{{enrollee.role_label}}"
+                data-section="{{section_id}}"
                 data-enrollment_type="{{enrollee.type}}"
                 data-toggle="tooltip" title="Add {{enrollee.user.name}} to this section" data-original-title="Add {{enrollee.user.name}} to this section"/>
             {% endif %}
 
             {% if allow_delete %}
-                <a href="#" class="remover icon-removeUser" id="{{enrollee.id}}" data-to_section="{{section_id}}" data-toggle="tooltip" title="Remove {{enrollee.user.name}} from this section" data-original-title="Remove {{enrollee.user.name}} from this section">
+                <a href="#" class="remover icon-removeUser" id="{{enrollee.id}}"
+                   data-enrollee-id="{{enrollee.id}}"
+                   data-enrollment_role_id="{{enrollee.role_id}}"
+                   data-enrollment_role_label="{{enrollee.role_label}}"
+                   data-user_name="{{enrollee.user.name}}"
+                   data-to_section="{{section_id}}"
+                   data-toggle="tooltip"
+                   data-original-title="Remove {{enrollee.user.name}} from this section"
+                   title="Remove {{enrollee.user.name}} from this section">
                     <i class="fa fa-trash-o"></i><span class="sr-only"> Remove student from section</span>
                 </a>
             {% endif %}
-            <span class="studentRole">{{enrollee.role|get_enroll_type_display}}</span>
+            <span class="studentRole">{{enrollee.role_label}}</span>
             <span class="studentName">{{enrollee.user.name}}</span>
             <span class="label label-{{enrollee.badge_label_name|lower}}">{{enrollee.badge_label_name|upper}}</span>
         </li>

--- a/manage_sections/templatetags/manage_sections_tags.py
+++ b/manage_sections/templatetags/manage_sections_tags.py
@@ -3,22 +3,6 @@ from django.template.defaultfilters import stringfilter
 
 register = template.Library()
 
-ENROLLMENT_TYPE_DICTIONARY = {
-    'TeacherEnrollment': 'Teacher',
-    'TaEnrollment': 'TA',
-    'Guest': 'Guest',
-    'ObserverEnrollment': 'Observer',
-    'DesignerEnrollment': 'Designer',
-    'StudentEnrollment': 'Student',
-    'Shopper': 'Shopper',
-    'StudentViewEnrollment': 'StudentView',
-}
-
-
-@register.filter
-def get_enroll_type_display(value):
-	return ENROLLMENT_TYPE_DICTIONARY.get(value, value)
-
 
 @register.filter(is_safe=True)
 @stringfilter

--- a/manage_sections/tests/test_utils.py
+++ b/manage_sections/tests/test_utils.py
@@ -177,3 +177,8 @@ class ContextUtilsTest(TestCase):
             self.request.LTI['custom_canvas_course_id']
         )
         self.assertEqual(res, True, 'Result should be True')
+
+
+def return_unmodified_input(input):
+    """ used for Mock side effects to spy on calls to a mapping method """
+    return input

--- a/manage_sections/tests/test_utils_unique_enrollments_not_in_section_filter.py
+++ b/manage_sections/tests/test_utils_unique_enrollments_not_in_section_filter.py
@@ -5,14 +5,16 @@ from manage_sections.utils import unique_enrollments_not_in_section_filter
 class UniqueEnrollmentsNotInSectionFilterUtilsTest(TestCase):
     longMessage = True
 
-    def enroll(self, user_id, role, section_id, sortable_name=''):
+    def enroll(self, user_id, role_id, section_id, sortable_name=''):
         """
         Helper method that returns a dict resembling an Enrollment JSON object passed
         back from the Canvas API.
+
+        role_id just has to be a String, so no need for it to be e.g. a number.
         """
         return {
             'user_id': user_id,
-            'role': role,
+            'role_id': role_id,
             'course_section_id': section_id,
         }
 
@@ -23,10 +25,10 @@ class UniqueEnrollmentsNotInSectionFilterUtilsTest(TestCase):
         current_section_id = 1234
         other_section_id = 5678
         enrollments = [
-            self.enroll(1, role='Student', section_id=current_section_id),
-            self.enroll(2, role='Teacher', section_id=other_section_id),
-            self.enroll(3, role='Student', section_id=current_section_id),
-            self.enroll(4, role='Observer', section_id=other_section_id),
+            self.enroll(1, role_id='Student', section_id=current_section_id),
+            self.enroll(2, role_id='Teacher', section_id=other_section_id),
+            self.enroll(3, role_id='Student', section_id=current_section_id),
+            self.enroll(4, role_id='Observer', section_id=other_section_id),
         ]
         # Should return the enrollments above that are not in current section
         expected_result = [enrollments[1], enrollments[3]]
@@ -40,9 +42,9 @@ class UniqueEnrollmentsNotInSectionFilterUtilsTest(TestCase):
         """
         current_section_id = 1234
         enrollments = [
-            self.enroll(1, role='Student', section_id=current_section_id),
-            self.enroll(2, role='Teacher', section_id=current_section_id),
-            self.enroll(3, role='Observer', section_id=current_section_id),
+            self.enroll(1, role_id='Student', section_id=current_section_id),
+            self.enroll(2, role_id='Teacher', section_id=current_section_id),
+            self.enroll(3, role_id='Observer', section_id=current_section_id),
         ]
         res = unique_enrollments_not_in_section_filter(current_section_id, enrollments)
         self.assertEqual(res, [], "Expected an empty list of enrollments!")
@@ -55,12 +57,12 @@ class UniqueEnrollmentsNotInSectionFilterUtilsTest(TestCase):
         current_section_id = 123
         other_section_ids = [45, 67, 89]
         enrollments = [
-            self.enroll(1, role='Student', section_id=other_section_ids[0]),
-            self.enroll(2, role='Teacher', section_id=other_section_ids[0]),
-            self.enroll(1, role='Student', section_id=other_section_ids[1]),
-            self.enroll(2, role='Teacher', section_id=other_section_ids[1]),
-            self.enroll(1, role='Student', section_id=other_section_ids[2]),
-            self.enroll(2, role='Teacher', section_id=other_section_ids[2]),
+            self.enroll(1, role_id='Student', section_id=other_section_ids[0]),
+            self.enroll(2, role_id='Teacher', section_id=other_section_ids[0]),
+            self.enroll(1, role_id='Student', section_id=other_section_ids[1]),
+            self.enroll(2, role_id='Teacher', section_id=other_section_ids[1]),
+            self.enroll(1, role_id='Student', section_id=other_section_ids[2]),
+            self.enroll(2, role_id='Teacher', section_id=other_section_ids[2]),
         ]
         # Should return the last of each unique user_id/role combo
         expected_result = [enrollments[4], enrollments[5]]
@@ -76,12 +78,12 @@ class UniqueEnrollmentsNotInSectionFilterUtilsTest(TestCase):
         current_section_id = 123
         other_section_ids = [45, 67, 89]
         enrollments = [
-            self.enroll(1, role='Student', section_id=other_section_ids[0]),
-            self.enroll(1, role='Teacher', section_id=other_section_ids[0]),
-            self.enroll(1, role='Observer', section_id=other_section_ids[1]),
-            self.enroll(1, role='Teacher', section_id=other_section_ids[1]),
-            self.enroll(1, role='Student', section_id=other_section_ids[2]),
-            self.enroll(1, role='Observer', section_id=other_section_ids[2]),
+            self.enroll(1, role_id='Student', section_id=other_section_ids[0]),
+            self.enroll(1, role_id='Teacher', section_id=other_section_ids[0]),
+            self.enroll(1, role_id='Observer', section_id=other_section_ids[1]),
+            self.enroll(1, role_id='Teacher', section_id=other_section_ids[1]),
+            self.enroll(1, role_id='Student', section_id=other_section_ids[2]),
+            self.enroll(1, role_id='Observer', section_id=other_section_ids[2]),
         ]
         # Should return the last of each unique user_id/role combo
         expected_result = [enrollments[5], enrollments[4], enrollments[3]]
@@ -97,8 +99,8 @@ class UniqueEnrollmentsNotInSectionFilterUtilsTest(TestCase):
         current_section_id = 123
         other_section_id = 89
         enrollments = [
-            self.enroll(1, role='Student', section_id=current_section_id),
-            self.enroll(1, role='Teacher', section_id=other_section_id),
+            self.enroll(1, role_id='Student', section_id=current_section_id),
+            self.enroll(1, role_id='Teacher', section_id=other_section_id),
         ]
         res = unique_enrollments_not_in_section_filter(current_section_id, enrollments)
         # Order doesn't matter here, so use itemsEqual instead of listEqual

--- a/manage_sections/tests/test_view_add_to_section.py
+++ b/manage_sections/tests/test_view_add_to_section.py
@@ -50,12 +50,12 @@ class SectionAddToSectionViewTest(unittest.TestCase):
             "users_to_add": [
                 {
                     "enrollment_user_id": "79610",
-                    "enrollment_role": "TeacherEnrollment",
+                    "enrollment_role_id": "2",
                     "enrollment_type": "TeacherEnrollment"
                 },
                 {
                     "enrollment_user_id": "104779",
-                    "enrollment_role": "TeacherEnrollment",
+                    "enrollment_role_id": "2",
                     "enrollment_type": "TeacherEnrollment"
                 }
             ]
@@ -92,7 +92,7 @@ class SectionAddToSectionViewTest(unittest.TestCase):
             self.add_to_section_stub_body['section_id'],
             user_to_add['enrollment_user_id'],
             enrollment_type=user_to_add['enrollment_type'],
-            enrollment_role=user_to_add['enrollment_role'],
+            enrollment_role_id=user_to_add['enrollment_role_id'],
             enrollment_enrollment_state='active',
         )
 

--- a/manage_sections/tests/test_view_section_class_list.py
+++ b/manage_sections/tests/test_view_section_class_list.py
@@ -5,11 +5,13 @@ from django_auth_lti import const
 from mock import patch, ANY, DEFAULT, Mock, MagicMock
 
 from manage_sections.views import section_class_list
+from test_utils import return_unmodified_input
 
 
 @patch.multiple('manage_sections.views.canvas_api_helper_enrollments', get_enrollments=DEFAULT)
 @patch.multiple('manage_sections.views.canvas_api_helper_sections', get_section=DEFAULT)
 @patch.multiple('lti_permissions.decorators', is_allowed=Mock(return_value=True))
+@patch.multiple('manage_sections.views.canvas_api_helper_enrollments', add_role_labels_to_enrollments=DEFAULT)
 @patch.multiple(
     'manage_sections.views',
     render=DEFAULT,
@@ -34,26 +36,20 @@ class SectionClassListViewTest(TestCase):
         }
 
     @patch('manage_sections.views.unique_enrollments_not_in_section_filter')
-    def test_enrollment_filter_called(self, mock_filter, SDK_CONTEXT, render, get_section, is_editable_section, get_enrollments):
-        """
-        Test that view function makes a call to unique_enrollments filter with expected args
-        """
-        section_class_list(self.request, self.section_id)
-        mock_filter.assert_called_with(self.section_id, [])
-
-    @patch('manage_sections.views.unique_enrollments_not_in_section_filter')
-    def test_view_rendered_on_success(self, mock_filter, SDK_CONTEXT, render, get_section, is_editable_section, get_enrollments):
+    def test_view_rendered_on_success(self, mock_filter, add_role_labels_to_enrollments, render, **kwargs):
         """
         Test that view renders expected template on success
         """
+        add_role_labels_to_enrollments.side_effect = return_unmodified_input
         section_class_list(self.request, self.section_id)
         render.assert_called_with(self.request, 'manage_sections/_section_classlist.html', ANY)
 
     @patch('manage_sections.views._add_badge_label_name_to_enrollments')
-    def test_enrollments_sorted_on_success(self, mock_filter, SDK_CONTEXT, render, get_section, is_editable_section, get_enrollments):
+    def test_enrollments_sorted_on_success(self, mock_filter, add_role_labels_to_enrollments, **kwargs):
         """
         Test that enrollments list is sorted before being passed to render
         """
+        add_role_labels_to_enrollments.side_effect = return_unmodified_input
         enrollments_list_mock = MagicMock(name='enrollments', spec=list)
         mock_filter.return_value = enrollments_list_mock
         section_class_list(self.request, self.section_id)
@@ -62,10 +58,11 @@ class SectionClassListViewTest(TestCase):
 
     @patch('manage_sections.views._add_badge_label_name_to_enrollments')
     @patch('manage_sections.views.unique_enrollments_not_in_section_filter')
-    def test_enrollments_rendered_on_success(self, mock_filter, badge_filter, SDK_CONTEXT, render, get_section, is_editable_section, get_enrollments):
+    def test_enrollments_rendered_on_success(self, mock_filter, badge_filter, add_role_labels_to_enrollments, render, **kwargs):
         """
         Test that sorted enrollments list is passed on to the rendered template
         """
+        add_role_labels_to_enrollments.side_effect = return_unmodified_input
         mock_enrollment_1 = {'user': {'sortable_name': 'e'}}
         mock_enrollment_2 = {'user': {'sortable_name': 'f'}}
         mock_enrollment_3 = {'user': {'sortable_name': 'g'}}

--- a/manage_sections/tests/test_views_section_user_list.py
+++ b/manage_sections/tests/test_views_section_user_list.py
@@ -2,11 +2,14 @@ from unittest import TestCase
 
 from django.test import RequestFactory
 from django_auth_lti import const
-from mock import patch, ANY, Mock
+from mock import patch, ANY, Mock, DEFAULT
 
 from manage_sections.views import section_user_list
+from test_utils import return_unmodified_input
+
 
 @patch.multiple('lti_permissions.decorators', is_allowed=Mock(return_value=True))
+@patch.multiple('manage_sections.views.canvas_api_helper_enrollments', add_role_labels_to_enrollments=DEFAULT)
 class SectionUserListViewTest(TestCase):
     longMessage = True
 
@@ -45,10 +48,11 @@ class SectionUserListViewTest(TestCase):
     @patch('manage_sections.views.canvas_api_helper_sections.get_section')
     @patch('manage_sections.views.logger.error')  # Mock the logger to keep log messages off the console.
     def test_section_user_list_on_section_id_numeric_string(self, log_replacement, section_replacement,
-                                                            render_replacement):
+                                                            render_replacement, add_role_labels_to_enrollments, **kwargs):
         """Display section_user_list page when section id is numeric string(sucessful test case) """
         request = self.request
         request.section_id = 123
+        add_role_labels_to_enrollments.side_effect = return_unmodified_input
         section_replacement.return_value = self.SOME_SECTION
         response = section_user_list(request, request.section_id)
         render_replacement.assert_called_with(request, 'manage_sections/_section_userlist.html', {
@@ -63,10 +67,11 @@ class SectionUserListViewTest(TestCase):
     @patch('manage_sections.views.canvas_api_helper_sections.get_section')
     @patch('manage_sections.views.logger.error')  # Mock the logger to keep log messages off the console.
     def test_section_user_list_when_primary(self, log_replacement, section_replacement, is_editable_section,
-                                            render_replacement):
+                                            render_replacement, add_role_labels_to_enrollments, **kwargs):
         """Display section_user_list page when section id is numeric string(successful test case) """
         request = self.request
         request.section_id = '123'
+        add_role_labels_to_enrollments.side_effect = return_unmodified_input
         section_replacement.return_value = self.SOME_SECTION
         is_editable_section.return_value = False
         response = section_user_list(request, request.section_id)
@@ -77,10 +82,11 @@ class SectionUserListViewTest(TestCase):
     @patch('manage_sections.views.canvas_api_helper_sections.get_section')
     @patch('manage_sections.views.logger.error')  # Mock the logger to keep log messages off the console.
     def test_section_user_list_when_not_primary(self, log_replacement, section_replacement, is_editable_section,
-                                                render_replacement):
+                                                render_replacement, add_role_labels_to_enrollments, **kwargs):
         """Display section_user_list page when section id is numeric string(sucessful test case) """
         request = self.request
         request.section_id = '123'
+        add_role_labels_to_enrollments.side_effect = return_unmodified_input
         section_replacement.return_value = self.SOME_SECTION
         is_editable_section.return_value = True
         response = section_user_list(request, request.section_id)

--- a/manage_sections/utils.py
+++ b/manage_sections/utils.py
@@ -16,7 +16,7 @@ def role_key(enrollment):
     """
     Return a tuple key for an enrollment record based on user_id and role
     """
-    return enrollment['user_id'], enrollment['role']
+    return enrollment['user_id'], enrollment['role_id']
 
 
 def unique_enrollments_not_in_section_filter(section_id, enrollments):


### PR DESCRIPTION
(not just a hardcoded set)
- supports transition of Shopper role to Prospective Enrollee

