### PR TITLE
Upgrade version of django_icommons_common

### DIFF
--- a/canvas_manage_course/requirements/base.txt
+++ b/canvas_manage_course/requirements/base.txt
@@ -13,5 +13,5 @@ requests==2.9.1
 
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.8.4#egg=canvas-python-sdk==0.8.4
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.5#egg=django-auth-lti==1.2.5
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.14#egg=django-icommons-common[async]==1.14
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.14.1#egg=django-icommons-common[async]==1.14.1
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v1.2.1#egg=django-icommons-ui==1.2.1


### PR DESCRIPTION
Note: this depends on https://github.com/Harvard-University-iCommons/django-icommons-common/pull/159 