### PR TITLE
tlt-2741: manage sections - text changes

### DIFF
--- a/manage_sections/templates/manage_sections/section_details.html
+++ b/manage_sections/templates/manage_sections/section_details.html
@@ -27,13 +27,13 @@
                 {% endif %}
                 
                 <div id="pane-left">
-                   {{section_name}}: <span class="enroll_count"></span> assigned student<span class="enroll_count_pluralize"></span>
+                   {{section_name}}: <span class="enroll_count"></span> user<span class="enroll_count_pluralize"></span>
                    <div id="sectionUsers">
                    </div>
                 </div>
                 <div id="pane-right" class="close-right-pane">
                     {% if allow_edit %}
-                        You have selected <span class="selection_count">0</span> unassigned student<span class="selection_count_pluralize">s</span>
+                        You have selected <span class="selection_count">0</span> user<span class="selection_count_pluralize">s</span>
                         <button class="btn btn-primary pull-right add-selected-users" disabled><i class="fa fa-plus"></i> Add Selection</button>
                     {% endif %}
                     <div id="fullClassList">

--- a/manage_sections/templates/manage_sections/section_list.html
+++ b/manage_sections/templates/manage_sections/section_list.html
@@ -12,7 +12,7 @@
     </div>
     <a class="listNav-item showSection" href="{% url 'manage_sections:section_details' section_id=section.id %}">
         <span class="sectionName">{{ section.name }}</span>
-        (<span class="sectionCount">{{section.enrollment_count}}</span> users)
+        (<span class="sectionCount">{{section.enrollment_count}}</span> user{{ section.enrollment_count|pluralize }})
     </a>
     <div class="editMenu">
     {% if section.registrar_section_flag %}


### PR DESCRIPTION
- section details user count text changed from 'assigned student' to 'user' to match text elsewhere in the tool (screenshot A)
- pluralization is now working in section list user counts (e.g. on create_section_form.html)
(screenshot B)

Screenshot A:
<img width="200" alt="screen shot 2016-10-05 at 11 32 54 am" src="https://cloud.githubusercontent.com/assets/8975317/19120000/8ae8ed32-8aef-11e6-81b2-09b1120af077.png">

Screenshot B:
<img width="200" alt="screen shot 2016-10-05 at 11 32 27 am" src="https://cloud.githubusercontent.com/assets/8975317/19120006/914482ae-8aef-11e6-9b70-9b0a66470798.png">

