### PR TITLE
tlt-2769: cache control - all views expire immediately

### DIFF
--- a/canvas_manage_course/settings/base.py
+++ b/canvas_manage_course/settings/base.py
@@ -60,7 +60,10 @@ warnings.warn("lti_permissions is deprecated. Once lti_school_permissions "
               "into SchoolPermissions the lti_permission entry can be removed "
               "from INSTALLED_APPS.", DeprecationWarning)
 
+# Note: ordering of cache-related middleware is important, see
+# https://docs.djangoproject.com/en/1.8/topics/cache/#order-of-middleware-classes
 MIDDLEWARE_CLASSES = (
+    'django.middleware.cache.UpdateCacheMiddleware',
     'djangular.middleware.DjangularUrlMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -68,6 +71,7 @@ MIDDLEWARE_CLASSES = (
     'django_auth_lti.middleware_patched.MultiLTILaunchAuthMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.security.SecurityMiddleware',
+    'django.middleware.cache.FetchFromCacheMiddleware',
 )
 
 AUTHENTICATION_BACKENDS = (
@@ -166,6 +170,10 @@ CACHES = {
         'TIMEOUT': SECURE_SETTINGS.get('default_cache_timeout_secs', 300),
     }
 }
+
+# Tell proxy and browser caches that all dynamic views expire immediately.
+# @never_cache can be used on individual views to add further paranoia.
+CACHE_MIDDLEWARE_SECONDS = 0
 
 # RQ
 # http://python-rq.org/docs/


### PR DESCRIPTION
This is one way we could give more proxy + browser cache hints for our dynamic views generated by Django. @sapnamysore @cmurtaugh @bermudezjd 

Summary: Django does not send any cache-control-related response headers by default. There are two main ways to do so out-of-the-box: 1. **site-wide,** and 2. **per-view**.

**1. Site-wide**
The approach adopted here; all dynamic views have max-age and expires headers. This is accomplished through middleware and settings.

**2. Per-view**
Using decorators or even finer-grained Django cache-control helpers you can restrict cache control commands to individual views. The advantage of using e.g. `@never_cache` is that it is even more restrictive; it adds _no-cache, no-store, must-revalidate_ to the cache control header on top of _max-age_.

Another option, though requiring slightly more work and testing, would be to roll our own site-wide version of `@never_cache`, which seems extreme given we're not sure how big this problem really is for our users.

(As for **static files**, nginx does send response headers that help downstream caches figure out how to minimize unnecessary network calls. We could optimize this further if need be -- by explicitly setting a far-future expires header and regenerating the files with new filenames each time they're updated -- but we deemed this to be beyond the scope or need of the present ticket.)

PS - although we know empirically what happened in the situation described in TLT-2769, we didn't take much data on the event at the time, and I cannot reproduce this in Firefox currently. So it's hard to know whether the choice of option no. 1 will reduce this kind of caching issue; it was chosen because it's least intrusive. Hopefully the information here (and in TLT-2769) will guide these decisions in other use cases as well.