### PR TITLE
Modified the error message to  point  to the new wiki link.

### DIFF
--- a/manage_people/templates/manage_people/user_form.html
+++ b/manage_people/templates/manage_people/user_form.html
@@ -34,7 +34,7 @@
     <div id="user-removed-failed" class="infoBlock-error alert-lti hidden">
         <p>
             There was a problem removing '<span id="err_username"> </span>'. Please try again. If the problem persists,
-            please contact your <a href="http://tlt.harvard.edu/learn-more" target="_blank">local support staff</a>.
+            please contact your <a href="https://wiki.harvard.edu/confluence/display/canvas/Local+School+Support+Contacts" target="_blank">local support staff</a>.
         </p>
     </div>
 

--- a/manage_sections/templates/manage_sections/error.html
+++ b/manage_sections/templates/manage_sections/error.html
@@ -10,7 +10,7 @@
 <p>
   We are currently unable to process your request. Please try again.
   If the problem persists, please contact your
-  <a href="http://tlt.harvard.edu/learn-more" target="_blank">
+  <a href="https://wiki.harvard.edu/confluence/display/canvas/Local+School+Support+Contacts" target="_blank">
     local support staff</a>.
 </p>
 </body>

--- a/manage_sections/tests/test_view_create_section_form.py
+++ b/manage_sections/tests/test_view_create_section_form.py
@@ -169,3 +169,17 @@ class CreateSectionFormTest(unittest.TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, '/not_authorized')
 
+
+@patch.multiple('lti_school_permissions.decorators', is_allowed=Mock(return_value=True))
+class CreateSectionFormErrorMessageTest(CreateSectionFormTest):
+    def test_manage_section_error_message(self):
+        """
+        Validate error message when when Create Section Form view returns  error
+         page when there is no lis_course_offering_sourcedid
+        """
+        request = self.request
+        request.LTI['lis_course_offering_sourcedid'] = None
+        result = create_section_form(request)
+        self.assertTrue('wiki.harvard.edu/confluence/display/canvas/'
+                        'Local+School+Support+Contacts' in result.content)
+


### PR DESCRIPTION

Changes for [TLT-2939](https://jira.huit.harvard.edu/browse/TLT-2939) and [TLT-2938](https://jira.huit.harvard.edu/browse/TLT-2939) 

Attached screen shots in the ticket by tweaking values locally as it's tricky to reproduce the errors for ACP.   Also added unit test for manage_sections to validate the message.. Skipping it for  manage_people as it's in JS and it's an older project which has not been setup for such tests and not worth for a 1 point story.