### PR TITLE
tlt-2900: upgrades requirement to fix continuous integration unit tests

### DIFF
--- a/canvas_manage_course/requirements/base.txt
+++ b/canvas_manage_course/requirements/base.txt
@@ -13,4 +13,4 @@ git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.8.4#egg=canvas-python
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.5#egg=django-auth-lti==1.2.5
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.18.1#egg=django-icommons-common[async]==1.18.1
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v1.3.1#egg=django-icommons-ui==1.3.1
-git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions@v0.5#egg=django-canvas-lti-school-permissions==0.5
+git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions@v0.5.1#egg=django-canvas-lti-school-permissions==0.5.1


### PR DESCRIPTION
Please see https://github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions/pull/9 for a description of the changes in the underlying requirement.