### PR TITLE
tlt-3051: isites_migration settings cleanup per comments on PR 37

### DIFF
--- a/canvas_manage_course/requirements/base.txt
+++ b/canvas_manage_course/requirements/base.txt
@@ -13,4 +13,4 @@ git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.8.4#egg=canvas-python
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.5#egg=django-auth-lti==1.2.5
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.18.2#egg=django-icommons-common[async]==1.18.2
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v1.3.1#egg=django-icommons-ui==1.3.1
-git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions@v0.5.1#egg=django-canvas-lti-school-permissions==0.5.1
+git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions@v0.5.2#egg=django-canvas-lti-school-permissions==0.5.2

--- a/canvas_manage_course/settings/isites_migration.py
+++ b/canvas_manage_course/settings/isites_migration.py
@@ -12,9 +12,6 @@ INSTALLED_APPS = (
     'django_rq',
     'icommons_common',
     'isites_migration',
-    'lti_school_permissions',
-    'manage_people',
-    'manage_sections',
 )
 
 # Settings specifically for the isites_migration LTI app

--- a/manage_people/models.py
+++ b/manage_people/models.py
@@ -15,6 +15,7 @@ class ManagePeopleRole(models.Model):
     xid_allowed = models.BooleanField(default=False)
 
     class Meta:
+        app_label = u'manage_people'
         db_table = u'manage_people_role'
 
     def __unicode__(self):
@@ -37,6 +38,7 @@ class SchoolAllowedRole(models.Model):
     xid_allowed = models.BooleanField(default=False)
 
     class Meta:
+        app_label = u'manage_people'
         db_table = u'school_allowed_role'
         unique_together = ('school_id', 'user_role')
 


### PR DESCRIPTION
- manage_people now supports Django 1.9 requirement for non-INSTALLED_APPS model references to include app_label
Requires https://github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions/pull/10