### PR TITLE
TLT-3406 Manage section caching fix

### DIFF
--- a/canvas_manage_course/requirements/base.txt
+++ b/canvas_manage_course/requirements/base.txt
@@ -12,6 +12,6 @@ requests==2.13.0
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.10.2#egg=canvas-python-sdk==0.10.2
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.9#egg=django-auth-lti==1.2.9
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.37#egg=django-icommons-common[async]==v1.37
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.37.1#egg=django-icommons-common[async]==v1.37.1
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v1.5.3#egg=django-icommons-ui==1.5.3
 git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions@v0.6#egg=django-canvas-lti-school-permissions==0.6

--- a/canvas_manage_course/settings/base.py
+++ b/canvas_manage_course/settings/base.py
@@ -260,12 +260,17 @@ LOGGING = {
             'propagate': False,
         },
         'manage_people': {
-            'handlers': ['default'],
+            'handlers': ['default', 'console'],
+            'level': _DEFAULT_LOG_LEVEL,
+            'propagate': False,
+        },
+        'manage_sections': {
+            'handlers': ['default', 'console'],
             'level': _DEFAULT_LOG_LEVEL,
             'propagate': False,
         },
         'manage_people_audit_log': {
-            'handlers': ['default'],
+            'handlers': ['default', 'console'],
             'level': _DEFAULT_LOG_LEVEL,
             'propagate': False,
         },

--- a/manage_sections/views.py
+++ b/manage_sections/views.py
@@ -365,12 +365,13 @@ def add_to_section(request):
                 enrollment_role_id=user['enrollment_role_id'],
                 enrollment_enrollment_state='active'
             )
-            canvas_api_helper_courses.delete_cache(canvas_course_id=canvas_course_id)
-            canvas_api_helper_enrollments.delete_cache(canvas_course_id)
-            canvas_api_helper_sections.delete_cache(canvas_course_id)
         except (KeyError, CanvasAPIError):
             logger.exception("Failed to add user to section %s %s", section_id, json.dumps(user))
             failed_users.append(user)
+    canvas_api_helper_courses.delete_cache(canvas_course_id=canvas_course_id)
+    canvas_api_helper_enrollments.delete_cache(canvas_course_id)
+    canvas_api_helper_sections.delete_cache(canvas_course_id)
+    canvas_api_helper_sections.delete_section_cache(section_id)
 
     return JsonResponse({
         'added': len(users_to_add) - len(failed_users),
@@ -393,9 +394,13 @@ def remove_from_section(request):
         canvas_api_helper_courses.delete_cache(canvas_course_id=canvas_course_id)
         canvas_api_helper_enrollments.delete_cache(canvas_course_id)
         canvas_api_helper_sections.delete_cache(canvas_course_id)
+        canvas_api_helper_sections.delete_section_cache(user_section_id)
+
     except CanvasAPIError:
         message = "Failed to remove user from section %s in course %s", user_section_id, canvas_course_id
         logger.exception(message)
+        canvas_api_helper_sections.delete_cache(canvas_course_id)
+        canvas_api_helper_sections.delete_section_cache(user_section_id)
         return JsonResponse({'message': message}, status=500)
 
     return JsonResponse(response.json())


### PR DESCRIPTION
https://jira.huit.harvard.edu/browse/TLT-3406
Started off with what was done in the 1.11.3 hotfix and merged into my branch which was created off of develop.
Instead of deleting the cache on every add or delete, I added the clearing of cache when we get the section user list.
Currently deployed on dev.
https://canvas.dev.tlt.harvard.edu/courses/4342/external_tools/190