### PR TITLE
TLT 3396 Manage People, only enrollments with allowable roles to be deleted

### DIFF
--- a/class_roster/views.py
+++ b/class_roster/views.py
@@ -64,12 +64,12 @@ def _get_roster_url(course_instance, user_id):
     term_code = str(
         course_instance.get('term', {}).get('term_code', '')).strip()
     if calendar_year == '' or cs_class_number == '' or term_code == '':
-        logger.error('Class roster tool cannot build a my.harvard class roster'
-                     ' link for course instance {}, as it is missing required'
-                     ' information: calendar_year={}; cs_class_number={};'
-                     ' term_code={}'.format(
-                     course_instance.get('course_instance_id', '(unknown)'),
-                     calendar_year, cs_class_number, term_code))
+        logger.warning('Class roster tool cannot build a my.harvard class roster'
+                       ' link for course instance {}, as it is missing required'
+                       ' information: calendar_year={}; cs_class_number={};'
+                       ' term_code={}'.format(
+                        course_instance.get('course_instance_id', '(unknown)'),
+                        calendar_year, cs_class_number, term_code))
         return None  # we cannot build a link for this course instance; skip it
 
     cs_term_code = '{}{}{}'.format(calendar_year[0],  # [y]yyy

--- a/manage_people/static/manage_people/css/manage_people.css
+++ b/manage_people/static/manage_people/css/manage_people.css
@@ -918,6 +918,13 @@ aside h2 {
   opacity: 0.65;
   filter: alpha(opacity=65);
 }
+.delete-icon-disabled-tooltip {
+  padding: 0.5em;
+  color: #000;
+  cursor: not-allowed;
+  opacity: 0.65;
+  filter: alpha(opacity=65);
+}
 .modal-open {
   overflow: hidden;
 }

--- a/manage_people/templates/manage_people/user_form.html
+++ b/manage_people/templates/manage_people/user_form.html
@@ -63,7 +63,11 @@
             data-user-role-id="{{ enrollee.user_role_id}}"
             data-canvas-role-label="{{ enrollee.canvas_role_label}}">
 
-            <a class="deleteMenu delete-icon" href="#"><i class="fa fa-trash"></i></a>
+            {% if enrollee.can_be_deleted %}
+                <a class="deleteMenu delete-icon" href="#"><i class="fa fa-trash"></i></a>
+            {% else %}
+                <a class="deleteMenu delete-icon-disabled" href="#"><i class="fa fa-trash"></i></a>
+            {% endif %}
             <span class="roster_user_name">{{ enrollee.user.sortable_name }}</span>
             <span class="label">{{ enrollee.badge_label_name }}</span>
             <span class="float-right text-strong">{{ enrollee.canvas_role_label }}</span>

--- a/manage_people/templates/manage_people/user_form.html
+++ b/manage_people/templates/manage_people/user_form.html
@@ -66,7 +66,7 @@
             {% if enrollee.can_be_deleted %}
                 <a class="deleteMenu delete-icon" href="#"><i class="fa fa-trash"></i></a>
             {% else %}
-                <a class="deleteMenu delete-icon-disabled" href="#"><i class="fa fa-trash"></i></a>
+                <a class="delete-icon-disabled-tooltip" href="#" data-toggle="tooltip" title="This enrollment can only be deleted by an admin due to the users role."><i class="fa fa-trash"></i></a>
             {% endif %}
             <span class="roster_user_name">{{ enrollee.user.sortable_name }}</span>
             <span class="label">{{ enrollee.badge_label_name }}</span>
@@ -81,6 +81,13 @@
 
 {% block javascript %}
     {{ block.super }}
+    <script type="text/javascript">
+        $(document).ready(function(){
+            $('[data-toggle="tooltip"]').tooltip({
+                placement : 'top'
+            });
+        });
+    </script>
     <script>
         var removeUserURL = "{% url 'manage_people:remove_user' %}";
     </script>

--- a/manage_people/views.py
+++ b/manage_people/views.py
@@ -507,6 +507,10 @@ def get_enrollments_added_through_tool(sis_course_id):
         user_id = enrollment['user'].get('sis_user_id')
         if user_id and user_id in user_badge_info_mapping:
             enrollment['badge_label_name'] = user_badge_info_mapping[user_id]
+        # Check if the given enrollment can be deleted in the current tool
+        # If it can not, we want to disable the delete option in the template
+        user_role = get_user_role_if_permitted(sis_course_id, enrollment['user_role_id'])
+        enrollment['can_be_deleted'] = True if user_role is not None else False
 
     return filtered_enrollments
 


### PR DESCRIPTION
TLT-3545 - Changed logging statement from error to warning
TLT-3396 - Only allow deletions of enrollments from the manage people tool for the roles that the tool is allowed to manage.

Currently deployed on dev
https://canvas.dev.tlt.harvard.edu/courses/2300/external_tools/195
Only the 'Petitioner' enrollment should be blocked from deletion