### PR TITLE
Hotfix v2.1.1: Skip canvas roles that are not in user_roles

### DIFF
--- a/manage_people/utils.py
+++ b/manage_people/utils.py
@@ -224,8 +224,11 @@ def get_user_role_to_canvas_role_map(account_id='self'):
     canvas_roles_by_canvas_role_id = get_roles_for_account_id(account_id)
     user_roles = list(UserRole.objects.values())
     role_map = {
-        role['role_id']: canvas_roles_by_canvas_role_id[role['canvas_role_id']]
-        for role in user_roles if role.get('canvas_role_id')}
+        role["role_id"]: canvas_roles_by_canvas_role_id[role["canvas_role_id"]]
+        for role in user_roles
+        if role.get("canvas_role_id")
+        and canvas_roles_by_canvas_role_id.get(role["canvas_role_id"])
+    }
 
     logger.debug(
         "Caching user_role_id:Canvas role map for Canvas account %s: %s",

--- a/manage_people/views.py
+++ b/manage_people/views.py
@@ -308,7 +308,12 @@ def add_users(request):
     labels_by_user_role_id = {
         role['role_id']: canvas_roles_by_role_id[
             int(role['canvas_role_id'])]['label']
-        for role in user_roles if role.get('canvas_role_id')}
+        for role in user_roles
+        if role.get('canvas_role_id')
+        and canvas_roles_by_role_id.get(
+            int(role['canvas_role_id'])
+        )
+    }
 
     # annotate enrollments with the Canvas role label
     for (_, person) in enrollment_results:


### PR DESCRIPTION
In order to fix issue where unexpected canvas roles were breaking role mappings.
