### PR TITLE
TLT-4040: Remove XID References from UI

### DIFF
--- a/manage_people/templates/manage_people/add_user_confirmation.html
+++ b/manage_people/templates/manage_people/add_user_confirmation.html
@@ -19,7 +19,12 @@
     <ul class="list-with-floats" id="enrollment_confirmations">
         {% for existing_enrollment, enrollee in enrollment_results %}
             <li>
-                {{ enrollee.email_address }} <span class="label">{{ enrollee.badge_label }}</span>
+                {{ enrollee.email_address }}
+                {% if enrollee.badge_label != 'XID'%}
+                    <span class="label">{{ enrollee.badge_label }}</span>
+                {% else %}
+                    <span class="label">HKL</span>
+                {% endif %}
                 <div class="float-right">
                     {% if existing_enrollment %}
                         <span class="text-strong"><i class="fa fa-check"></i> Already enrolled as a {{ enrollee.canvas_role_label }}</span>

--- a/manage_people/templates/manage_people/results_list.html
+++ b/manage_people/templates/manage_people/results_list.html
@@ -68,7 +68,12 @@
                       data-role="{{ role.role }}"
                       data-role-id="{{ role.role_id }}"
                       data-role-label="{{ role.canvas_role_label }}">
-                    {{ person.email_address }} <span class="label">{{ person.badge_label_name }}</span>
+                    {{ person.email_address }}
+                    {% if person.badge_label_name != 'XID' %}
+                        <span class="label">{{ person.badge_label_name }}</span>
+                    {% else %}
+                        <span class="label">HKL</span>
+                    {% endif %}
                     <span class="float-right text-strong">
                       Enrolled as a {{ role.canvas_role_label }}
                     </span>
@@ -108,7 +113,11 @@
                             {% endif %}
                             <label class="plain" for="record-{{ forloop.counter }}">
                                 {{ result.name_first }} {{ result.name_last }} ({{ result.email_address }})
-                                <span class="label">{{ result.badge_label_name }}</span>
+                                {% if result.badge_label_name != 'XID' %}
+                                    <span class="label">{{ result.badge_label_name }}</span>
+                                {% else %}
+                                    <span class="label">HKL</span>
+                                {% endif %}
                             </label>
                             
                             <div class="float-right">

--- a/manage_people/templates/manage_people/user_form.html
+++ b/manage_people/templates/manage_people/user_form.html
@@ -68,8 +68,15 @@
             {% else %}
                 <a class="delete-icon-disabled-tooltip" href="#" data-toggle="tooltip" title="This enrollment can only be deleted by an admin due to the user's role."><i class="fa fa-trash"></i></a>
             {% endif %}
+
             <span class="roster_user_name">{{ enrollee.user.sortable_name }}</span>
-            <span class="label">{{ enrollee.badge_label_name }}</span>
+
+            {% if enrollee.badge_label_name != 'XID'%}
+                <span class="label">{{ enrollee.badge_label_name }}</span>
+            {% else %}
+                <span class="label">HKL</span>
+            {% endif %}
+
             <span class="float-right text-strong">{{ enrollee.canvas_role_label }}</span>
         </li>
         {% endfor %}

--- a/manage_sections/templates/manage_sections/_enrollments_list_by_name.html
+++ b/manage_sections/templates/manage_sections/_enrollments_list_by_name.html
@@ -51,7 +51,11 @@
             {% endif %}
             <span class="studentRole">{{enrollee.role_label}}</span>
             <span class="studentName">{{enrollee.user.name}}</span>
-            <span class="label label-{{enrollee.badge_label_name|lower}}">{{enrollee.badge_label_name|upper}}</span>
+            {% if enrollee.badge_label_name != 'XID' %}
+                <span class="label label-{{enrollee.badge_label_name|lower}}">{{enrollee.badge_label_name|upper}}</span>
+            {% else %}
+                <span class="label label-{{enrollee.badge_label_name|lower}}">HKL</span>
+            {% endif %}
         </li>
     {% endfor %}
 {% endfor %}


### PR DESCRIPTION
Resolves [TLT-4080](https://jira.huit.harvard.edu/browse/TLT-4080).

Parts of the Canvas Manage Course UI have been updated to reflect the recent migration to Harvard Key Light (HKL). The changes correspond to those highlighted in [this doc](https://docs.google.com/document/d/1iDVaWWVuDJOjNaCj46irS-gsMaCJcfRyxzAxFi0Fkv0/edit#). Specifically, this PR corresponds to sections 1a through 1e (labeled in the Notes section of each row).

This branch has been deployed to qa and dev and was tested using [this course](https://canvas.qa.tlt.harvard.edu/courses/9093/external_tools/2).