### PR TITLE
Upgrade to Django 3.2 and bump base image version to v3.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ parameters.*
 .vscode/
 # for pyenv local
 .python-version
+
+# files generated via `runserver_plus` CLI command
+*.crt
+*.key

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # syntax=docker/dockerfile:experimental
 
-FROM 482956169056.dkr.ecr.us-east-1.amazonaws.com/uw/python-postgres-build:v0.5 as build
+FROM 482956169056.dkr.ecr.us-east-1.amazonaws.com/uw/python-postgres-build:v3.10 as build
 COPY canvas_manage_course/requirements/*.txt /code/
-RUN --mount=type=ssh,id=build_ssh_key ./python_venv/bin/pip3 install wheel gunicorn && ./python_venv/bin/pip3 install -r aws.txt
+RUN --mount=type=ssh,id=build_ssh_key ./python_venv/bin/pip install wheel gunicorn && ./python_venv/bin/pip install -r aws.txt
 COPY . /code/
 RUN chmod a+x /code/docker-entrypoint.sh
 
-FROM 482956169056.dkr.ecr.us-east-1.amazonaws.com/uw/python-postgres-base:v0.5
+FROM 482956169056.dkr.ecr.us-east-1.amazonaws.com/uw/python-postgres-base:v3.10
 COPY --from=build /code /code/
 ENV PYTHONUNBUFFERED 1
 WORKDIR /code

--- a/README.md
+++ b/README.md
@@ -23,15 +23,15 @@ Particular difficulties are sometimes found when installing the following direct
 
 Run, and ensure the ENV environment var will be able to point the django-ssm-parameter-store library to appropriate SSM params (either locally, via a file, or on SSM, in which case ensure your local default AWS profile is authenticated to the correct environment and that you're on VPN so you can connect to non-local databases and caches).
 
-Note that the django-sslserver default server and port is 127.0.0.1:8000. If your LTI configuration was set up with a different port, e.g. 8443, you'll need to specify it as in the snippet below.
+Note that the runserver_plus default server and port is 127.0.0.1:8000. If your LTI configuration was set up with a different port, e.g. 8443, you'll need to specify it as in the snippet below.
 
 ```sh
 export ENV=dev
 export DJANGO_SETTINGS_MODULE=canvas_manage_course.settings.local
 # ensure you're connected to VPN
-python manage.py runsslserver
+python manage.py runserver_plus --cert-file cert.crt
 # to use a different port:
-# python manage.py runsslserver 127.0.0.1:8443
+python manage.py runserver_plus 127.0.0.1:8443 --cert-file cert.crt
 ```
 
 Access at https://local.tlt.harvard.edu:(port)/.

--- a/canvas_manage_course/requirements/base.txt
+++ b/canvas_manage_course/requirements/base.txt
@@ -21,5 +21,5 @@ git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.1.0#
 
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v2.6#egg=django-icommons-common==2.6
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v2.1#egg=django-icommons-ui==2.1
-git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions@patricktonne/update-for-django-3.2
+git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions@v2.0#egg=django-canvas-lti-school-permissions==2.0
 git+ssh://git@github.com/Harvard-University-iCommons/django-ssm-parameter-store.git@v0.6#egg=django-ssm-parameter-store==0.6

--- a/canvas_manage_course/requirements/base.txt
+++ b/canvas_manage_course/requirements/base.txt
@@ -1,25 +1,25 @@
-boto3==1.21.35
-Django==2.2.27
-cx-Oracle==7.2.2
-django-allow-cidr==0.3.1
+boto3==1.22.5
+Django==3.2.13
+cx-Oracle==8.3.0
+django-allow-cidr==0.4.0
 django-cached-authentication-middleware==0.2.2
-django-redis-cache==2.0.0
-hiredis==1.0.0
-kitchen==1.2.4
-redis==3.3.8
-psycopg2==2.8.6
+django-redis-cache==3.0.1
+hiredis==2.0.0
+kitchen==1.2.6
+redis==3.5.3
+psycopg2==2.9.3
 requests==2.27.1
-django-storages==1.7.1
-django_rq==2.1.0
-django-watchman==1.2.0
-splunk_handler==2.2.0
-python-json-logger==0.1.11
+django-storages==1.12.3
+django_rq==2.5.1
+django-watchman==1.3.0
+splunk_handler==3.0.0
+python-json-logger==2.0.2
 
 
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v1.2.0#egg=canvas-python-sdk==1.2.0
-git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.0.4#egg=django-auth-lti==2.0.4
+git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.1.0#egg=django-auth-lti==2.1.0
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v2.5#egg=django-icommons-common==2.5
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v2.0#egg=django-icommons-ui==2.0
-git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions@v1.0#egg=django-canvas-lti-school-permissions==1.0
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v2.6#egg=django-icommons-common==2.6
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v2.1#egg=django-icommons-ui==2.1
+git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions@patricktonne/update-for-django-3.2
 git+ssh://git@github.com/Harvard-University-iCommons/django-ssm-parameter-store.git@v0.6#egg=django-ssm-parameter-store==0.6

--- a/canvas_manage_course/requirements/local.txt
+++ b/canvas_manage_course/requirements/local.txt
@@ -4,15 +4,19 @@
 
 # below are requirements specific to the local environment
 
-ddt==1.1.1
-django-debug-toolbar==3.2.1
-django-sslserver==0.21
+ddt==1.4.4
+django-debug-toolbar==3.4.0
 
 
 mock==2.0.0
-pyvirtualdisplay==0.2.1
-requests-oauthlib==0.8.0
-selenium==2.53.2
-xlrd==1.0.0
+PyVirtualDisplay==3.0
+requests-oauthlib==1.3.1
+selenium==4.1.5
+xlrd==2.0.1
+
+# django-extensions + dependencies for `runserver_plus` local dev server
+django-extensions==3.1.5
+Werkzeug==2.0.3
+pyOpenSSL==22.0.0
 
 git+ssh://git@github.com/Harvard-University-iCommons/selenium_common.git@v1.4.3#egg=selenium-common==1.4.3

--- a/canvas_manage_course/settings/local.py
+++ b/canvas_manage_course/settings/local.py
@@ -5,7 +5,7 @@ ALLOWED_HOSTS = ['*']
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
-INSTALLED_APPS += ['debug_toolbar', 'sslserver']
+INSTALLED_APPS += ['debug_toolbar', 'django_extensions']
 MIDDLEWARE += ['debug_toolbar.middleware.DebugToolbarMiddleware']
 
 # For Django Debug Toolbar:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-./python_venv/bin/python3 manage.py migrate                  # Apply database migrations
-./python_venv/bin/python3 manage.py collectstatic --noinput  # Collect static files
+./python_venv/bin/python manage.py migrate                  # Apply database migrations
+./python_venv/bin/python manage.py collectstatic --noinput  # Collect static files
 
 # Start Gunicorn processes
 echo Starting Gunicorn.


### PR DESCRIPTION
Resolves [TLT-4258](https://jira.huit.harvard.edu/browse/TLT-4258) and [TLT-4239](https://jira.huit.harvard.edu/browse/TLT-4239).

This PR:
- Upgrades the app to Django 3.2.
- Updates the Dockerfile to use v3.10 of the build and base images.
- Replaces `django-sslserver` with `django-extensions` since the former is incompatible with Django 3.x.
- Uses an updated branch of [django-canvas-lti-school-permissions](https://github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions) that includes a couple of updates to maintain compatibility with Django 3.2.

These changes have been deployed to and tested in dev and QA (dev test course [here](https://canvas.dev.tlt.harvard.edu/courses/32133/external_tools/16) and QA test course [here](https://canvas.qa.tlt.harvard.edu/courses/82965/external_tools/2))

Note that this PR depends on https://github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions/pull/13.