### PR TITLE
Speed up the Manage Sections index view

### DIFF
--- a/canvas_manage_course/requirements/base.txt
+++ b/canvas_manage_course/requirements/base.txt
@@ -1,4 +1,4 @@
-boto3==1.22.5
+boto3==1.28.19
 Django==3.2.13
 cx-Oracle==8.3.0
 django-allow-cidr==0.4.0
@@ -15,11 +15,10 @@ django-watchman==1.3.0
 splunk_handler==3.0.0
 python-json-logger==2.0.2
 
+canvas_python_sdk @ git+ssh://git@github.com/Harvard-University-iCommons/canvas_python_sdk.git@v1.4.3-rc1
 
-git+ssh://git@github.com/penzance/canvas_python_sdk.git@v1.2.0#egg=canvas-python-sdk==1.2.0
-git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.1.0#egg=django-auth-lti==2.1.0
-
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v2.6#egg=django-icommons-common==2.6
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v2.1#egg=django-icommons-ui==2.1
-git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions@v2.0#egg=django-canvas-lti-school-permissions==2.0
-git+ssh://git@github.com/Harvard-University-iCommons/django-ssm-parameter-store.git@v0.6#egg=django-ssm-parameter-store==0.6
+django-auth-lti @ git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.1.0
+django-icommons-common @ git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v2.6
+django-icommons-ui @ git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v2.1
+django-canvas-lti-school-permissions @ git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions@v2.0
+django-ssm-parameter-store @ git+ssh://git@github.com/Harvard-University-iCommons/django-ssm-parameter-store.git@v0.6

--- a/canvas_manage_course/requirements/base.txt
+++ b/canvas_manage_course/requirements/base.txt
@@ -15,7 +15,7 @@ django-watchman==1.3.0
 splunk_handler==3.0.0
 python-json-logger==2.0.2
 
-canvas_python_sdk @ git+ssh://git@github.com/Harvard-University-iCommons/canvas_python_sdk.git@v1.4.3-rc1
+canvas_python_sdk @ git+ssh://git@github.com/Harvard-University-iCommons/canvas_python_sdk.git@v1.4.3
 
 django-auth-lti @ git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.1.0
 django-icommons-common @ git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v2.6

--- a/canvas_manage_course/requirements/local.txt
+++ b/canvas_manage_course/requirements/local.txt
@@ -15,8 +15,8 @@ selenium==4.1.5
 xlrd==2.0.1
 
 # django-extensions + dependencies for `runserver_plus` local dev server
-django-extensions==3.1.5
-Werkzeug==2.0.3
-pyOpenSSL==22.0.0
+django-extensions==3.2.3
+Werkzeug==2.3.6
+pyOpenSSL==23.2.0
 
 git+ssh://git@github.com/Harvard-University-iCommons/selenium_common.git@v1.4.3#egg=selenium-common==1.4.3

--- a/manage_sections/templates/manage_sections/create_section_form.html
+++ b/manage_sections/templates/manage_sections/create_section_form.html
@@ -23,7 +23,7 @@
     </div>
 
     <div class="row row-lti col-md-8">
-        
+
         <h3>Registrar Enrollment(s):</h3>
         <p><small>
           These sections are fed from the Registrar's office.
@@ -36,31 +36,32 @@
         <button id="addSection" class="btn btn-primary"><i class="fa fa-plus"></i> Add A Section</button>
         <h3>Section(s):</h3>
         <ul id="sectionsMenu" class="listNav list-group list-unstyled">
-             
+
             {%  for section in sections %}
                 {% include "manage_sections/section_list.html" with data=section %}
-            {% endfor %}    
+            {% endfor %}
         </ul>
-        
+        <p><span style="font-size: larger;">*</span> does not include teaching staff enrollments</p>
+
         <form class="hide" action="{% url 'manage_sections:create_section' %}" method="post" id="formId">
             <label for="newSectionName" class="sr-only">Enter a section name</label>
-            <input type="text" id="newSectionName" placeholder="Enter Section Name" class="form-control " /> 
+            <input type="text" id="newSectionName" placeholder="Enter Section Name" class="form-control " />
             <span class="closeInput closeAdd cancelAdd"><i class="fa fa-times cancelAdd"></i></span>
             <div id="formErr" class="hide">
                 <p class="text-danger">We've encountered an error creating the requested section. Please try again.</p>
             </div>
         </form>
-        
+
         <form class="hide" action="#" method="post" id="editSection">
             <input type="hidden" id="editSectionId"/>
             <label for="editSectionName" class="sr-only">Edit section name</label>
-            <input type="text" id="editSectionName" class="form-control " /> 
+            <input type="text" id="editSectionName" class="form-control " />
             <span class="closeInput closeEdit cancelEdit "><i class="fa fa-times cancelEdit"></i></span>
             <div id="formEditErr" class="hide">
                 <p class="text-danger">We've encountered an error creating the requested section. Please try again.</p>
             </div>
         </form>
-        
+
 
         <div class="modal fade" id="confirmDelSection" tabindex="-1" role="dialog" aria-labelledby="confirmDelSectionLabel" aria-hidden="true">
         <div class="modal-dialog">
@@ -90,17 +91,17 @@
 <script type="text/javascript">
 
 $(document).ready(function(){
-    //tooltip for buttons (done this way because of dynamically created icons)    
+    //tooltip for buttons (done this way because of dynamically created icons)
     $('body').tooltip({
         selector: '[rel=tooltip]'
     });
     $('[rel=tooltip]').tooltip({
         container: 'body'
     });
-    
+
 
     //the sections menu
-    var $menu = $('#sectionsMenu'); 
+    var $menu = $('#sectionsMenu');
 
     //the input field
     var $newSectionInput = $('#newSectionName');
@@ -133,7 +134,7 @@ $(document).ready(function(){
 
                     break;
                 }
-                
+
                 $menu.trigger('insertSection');
                 e.preventDefault();
                 break;
@@ -142,14 +143,14 @@ $(document).ready(function(){
                 e.preventDefault();
                 break;
         }
-       
+
     });
 
 
     //listen when the user has click away from the text input
     $(document).bind('mousedown',function(e){
         //checks to see the form input is visible
-        if ( !($newSectionInput.is(':hidden')) ) 
+        if ( !($newSectionInput.is(':hidden')) )
         {
             //closing the input text field when clicking on the x
             if ($(e.target).hasClass('cancelAdd')){
@@ -179,7 +180,7 @@ $(document).ready(function(){
             //cancel the edit operation by hiding form and restoring
             //to previous section name
             if ( $(e.target).hasClass('cancelEdit') )
-                cancelEditing();        
+                cancelEditing();
 
             //1 listens for mouse click and if the input is empty
             //keep the input open with error class
@@ -191,7 +192,7 @@ $(document).ready(function(){
                 $newSectionInput.focus();
                 $('#editSectionName').parent().addClass('has-error');
                 $('#editSectionName').attr('placeholder', 'You must provide a name');
-            
+
             }
             //allow them to click on the input field but once they click
             //outside then continue with the update
@@ -238,7 +239,7 @@ $(document).ready(function(){
         if ( $('#formErr').hasClass('showSection') )
             $('#formErr').removeClass('showSection').addClass('hide');
     });
-    
+
     //AJAX custom event
     $menu.bind('insertSection',function(){
         var posting = $.post( "{% url 'manage_sections:create_section' %}", { "section_name_input" : $("input#newSectionName").val()} );
@@ -248,13 +249,13 @@ $(document).ready(function(){
             $newSectionInput.val('');
             //toggle the text box after success
             $newSectionInput.trigger('toggle');
-            
+
         }).fail(function(xhr,textStatus) {
             $newSectionInput.val('');
             $newSectionInput.parent().addClass('has-error');
             $('#formErr').removeClass('hide').addClass('showSection');
         });
-      
+
     });
 
     //$editSectionForm holds the form that does the editing
@@ -271,7 +272,7 @@ $(document).ready(function(){
     //the height of the li at the moment that is been edited
     var $liToEditHeight;
 
-    //using .on method so that we can can click on dynamically 
+    //using .on method so that we can can click on dynamically
     //generated HTML elements
     $(document).on('click', '.editSection', function(){
         var url = this.href;
@@ -308,13 +309,13 @@ $(document).ready(function(){
         return false;
     });
 
-    //store the elements that are inside the <li> before the 
+    //store the elements that are inside the <li> before the
     //edit icon get's clicked
     function cancelEditing(){
         $liToEditChildren.appendTo($liToEdit);
-        $editSectionForm.removeClass('showSection').addClass('hide'); 
+        $editSectionForm.removeClass('showSection').addClass('hide');
     };
-    
+
     //listening to tab and enter. If the text input is empty then
     //throw an error else continue adding the section
     $(document).on('keydown', '#editSectionName', function(e){
@@ -353,7 +354,7 @@ $(document).ready(function(){
                     //call the AJAX update
                     editSection($('#editSectionName').val(), $editSectionForm.attr('action'), $sectionCount);
                 }
-                
+
                 e.preventDefault();
                 break;
             case 27:
@@ -368,7 +369,7 @@ $(document).ready(function(){
         }
     });
 
-    
+
     //removes the error styles for the input element
     //takes in a jquery object
     function removeHasError(ele) {
@@ -387,7 +388,7 @@ $(document).ready(function(){
         var formData = {"section_name_input" : sectionName, "enrollment_count" : sectionCount};
 
         $.ajax({
-                    url : url, 
+                    url : url,
                     type : "POST",
                     data : formData,
                     success : function(json) {
@@ -407,7 +408,7 @@ $(document).ready(function(){
                         else{
                             $('#editSectionName').val($sectionName);
                         }
-                        
+
                         $editSectionForm.removeClass('hide').addClass('showSection');
                         $('#editSectionName').parent().addClass('has-error');
                         $('#editSectionName').focus();

--- a/manage_sections/templates/manage_sections/section_list.html
+++ b/manage_sections/templates/manage_sections/section_list.html
@@ -13,7 +13,7 @@
         {% if section.enrollment_count == 'n/a' %}
             (enrollee count not available)
         {% else %}
-            (<span class="sectionCount">{{section.enrollment_count}}</span> student{{ section.enrollment_count|pluralize }})
+            (<span class="sectionCount">{{section.enrollment_count}}</span> student{{ section.enrollment_count|pluralize }}<span style="font-size: larger;">*</span>)
         {% endif %}
     </a>
     <div class="editMenu">

--- a/manage_sections/templates/manage_sections/section_list.html
+++ b/manage_sections/templates/manage_sections/section_list.html
@@ -13,7 +13,7 @@
         {% if section.enrollment_count == 'n/a' %}
             (enrollee count not available)
         {% else %}
-            (<span class="sectionCount">{{section.enrollment_count}}</span> user{{ section.enrollment_count|pluralize }})
+            (<span class="sectionCount">{{section.enrollment_count}}</span> student{{ section.enrollment_count|pluralize }})
         {% endif %}
     </a>
     <div class="editMenu">

--- a/manage_sections/templates/manage_sections/sis_enrollment_sections.html
+++ b/manage_sections/templates/manage_sections/sis_enrollment_sections.html
@@ -4,7 +4,7 @@
         {% if section.enrollment_count == 'n/a' %}
             (enrollee count not available)
         {% else %}
-            ({{section.enrollment_count}} users)
+            ({{section.enrollment_count}} student{{section.enrollment_count|pluralize}})
         {% endif %}
     </a>
 </li>

--- a/manage_sections/templates/manage_sections/sis_enrollment_sections.html
+++ b/manage_sections/templates/manage_sections/sis_enrollment_sections.html
@@ -4,7 +4,7 @@
         {% if section.enrollment_count == 'n/a' %}
             (enrollee count not available)
         {% else %}
-            ({{section.enrollment_count}} student{{section.enrollment_count|pluralize}})
+            ({{section.enrollment_count}} student{{section.enrollment_count|pluralize}}<span style="font-size: larger;">*</span>)
         {% endif %}
     </a>
 </li>

--- a/manage_sections/utils.py
+++ b/manage_sections/utils.py
@@ -10,7 +10,7 @@ from canvas_sdk.methods import (
 from canvas_sdk.exceptions import CanvasAPIError
 from icommons_common.canvas_utils import SessionInactivityExpirationRC
 from icommons_common.models import CourseInstance
-from icommons_common.canvas_api.helpers import (
+from canvas_sdk.canvas_api.helpers import (
     courses as canvas_api_helper_courses,
     enrollments as canvas_api_helper_enrollments,
     sections as canvas_api_helper_sections
@@ -120,7 +120,7 @@ def validate_course_id(section_canvas_course_id, request_canvas_course_id):
     # check and convert the canvas_id from request to an int
     if not isinstance(request_canvas_course_id, int):
         request_canvas_course_id = int(request_canvas_course_id)
-        
+
     if section_canvas_course_id == request_canvas_course_id:
         return True
     return False
@@ -139,7 +139,7 @@ def delete_enrollments(enrollments, course_id):
     """
     is_empty = False
     deleted_enrollments = []
-    
+
     if not enrollments:
         is_empty = True
         return (deleted_enrollments, is_empty)
@@ -172,14 +172,14 @@ def delete_enrollments(enrollments, course_id):
             )
             canvas_api_helper_sections.delete_cache(course_id)
             return (deleted_enrollments, is_empty)
-        
+
         canvas_api_helper_sections.delete_section_cache(user_section_id)
         deleted_enrollments.append(response)
-    
+
     is_empty = True
-    
+
     canvas_api_helper_courses.delete_cache(canvas_course_id=course_id)
     canvas_api_helper_enrollments.delete_cache(course_id)
     canvas_api_helper_sections.delete_cache(course_id)
-    
+
     return (deleted_enrollments, is_empty)

--- a/manage_sections/utils.py
+++ b/manage_sections/utils.py
@@ -10,7 +10,7 @@ from canvas_sdk.methods import (
 from canvas_sdk.exceptions import CanvasAPIError
 from icommons_common.canvas_utils import SessionInactivityExpirationRC
 from icommons_common.models import CourseInstance
-from canvas_sdk.canvas_api.helpers import (
+from canvas_api.helpers import (
     courses as canvas_api_helper_courses,
     enrollments as canvas_api_helper_enrollments,
     sections as canvas_api_helper_sections

--- a/manage_sections/views.py
+++ b/manage_sections/views.py
@@ -14,7 +14,7 @@ from canvas_sdk.exceptions import CanvasAPIError
 
 from icommons_common.models import Person
 from icommons_common.monitor.views import BaseMonitorResponseView
-from canvas_sdk.canvas_api.helpers import (
+from canvas_api.helpers import (
     courses as canvas_api_helper_courses,
     enrollments as canvas_api_helper_enrollments,
     sections as canvas_api_helper_sections


### PR DESCRIPTION
This PR makes a change to the way that the Manage Sections index view is rendered to reduce/eliminate timeouts for courses that have a large number of sections. 

Prior to this change we would fetch all of the course sections, and then if there were <250 students total we would make separate calls to fetch the enrollment for each section. This was causing timeouts for courses that have <250 students but a large number of sections (~40). 

The Canvas API provides an option for fetching the `total_students` count along with the section metadata _without_ having to separately fetch all of the enrollments. This PR changes the index view to use the `total_students` count instead of fetching all of the enrollments (regardless of the total class size). 

Also added a note to indicate that the counts are students only:
![image (4)](https://github.com/Harvard-University-iCommons/canvas_manage_course/assets/104486/07d3f553-17cd-4a71-aa3d-b6b33ebe32bd)
