### PR TITLE
Fix Manage People search timeouts

### DIFF
--- a/canvas_manage_course/settings/base.py
+++ b/canvas_manage_course/settings/base.py
@@ -317,7 +317,7 @@ CANVAS_SDK_SETTINGS = {
     'auth_token': SECURE_SETTINGS.get('canvas_token', None),
     'base_api_url': CANVAS_URL + '/api',
     'max_retries': 3,
-    'per_page': 40,
+    'per_page': 100,
     'session_inactivity_expiration_time_secs': 50,
 }
 


### PR DESCRIPTION
This PR changes some of the logic that we use when searching for people to add to the course.  One of the steps involves finding any existing enrollments for people who are returned by the search. Prior to this change, the code would fetch _all_ of the enrollments for the course and look for any with a matching user_id. 
Now the code will fetch enrollments in the course _just for the people returned by the search_. For courses with lots of enrollments this will greatly speed up the search results view. 
Also added caching of UserRole objects and increased the Canvas API default page size for some additional performance improvement.