### PR TITLE
TLT-3949: Add build info

### DIFF
--- a/canvas_manage_course/requirements/local.txt
+++ b/canvas_manage_course/requirements/local.txt
@@ -7,7 +7,7 @@
 ddt==1.4.4
 django-debug-toolbar==3.4.0
 
-
+oracledb==1.4.0
 mock==2.0.0
 PyVirtualDisplay==3.0
 requests-oauthlib==1.3.1

--- a/canvas_manage_course/settings/base.py
+++ b/canvas_manage_course/settings/base.py
@@ -19,6 +19,11 @@ from django.urls import reverse_lazy
 
 from dj_secure_settings.loader import load_secure_settings
 
+try:
+    from build_info import BUILD_INFO
+except ImportError:
+    BUILD_INFO = {}
+
 SECURE_SETTINGS = load_secure_settings()
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/canvas_manage_course/settings/local.py
+++ b/canvas_manage_course/settings/local.py
@@ -1,3 +1,9 @@
+import sys
+import oracledb
+oracledb.version = "8.3.0"
+sys.modules["cx_Oracle"] = oracledb
+import cx_Oracle
+
 from .base import *
 from logging.config import dictConfig
 

--- a/canvas_manage_course/templates/canvas_manage_course/dashboard_course.html
+++ b/canvas_manage_course/templates/canvas_manage_course/dashboard_course.html
@@ -130,6 +130,11 @@
       </div>
     </div>
   {% endif %}
+
+  {# Place build information into a HTML comment to avoid cluttering the page for users #}
+  {% if build_info %}
+      <!-- BUILD INFO: {{ build_info.image_tag }} | {{ build_info.image_hash_tag }} | {{ build_info.build_timestamp }} -->
+  {% endif %}
 {% endif %}
 </main>
 

--- a/canvas_manage_course/templates/canvas_manage_course/dashboard_course.html
+++ b/canvas_manage_course/templates/canvas_manage_course/dashboard_course.html
@@ -130,12 +130,12 @@
       </div>
     </div>
   {% endif %}
-
-  {# Place build information into a HTML comment to avoid cluttering the page for users #}
-  {% if build_info %}
-      <!-- BUILD INFO: {{ build_info.image_tag }} | {{ build_info.image_hash_tag }} | {{ build_info.build_timestamp }} -->
-  {% endif %}
 {% endif %}
 </main>
+{# Place build information into a HTML comment to avoid cluttering the page for users #}
+{% if build_info %}
+<!-- BUILD INFO: {{ build_info.image_tag }} | {{ build_info.image_hash_tag }} | {{ build_info.build_timestamp }} -->
+{% endif %}
+
 
 {% endblock tool_content %}

--- a/canvas_manage_course/views.py
+++ b/canvas_manage_course/views.py
@@ -3,6 +3,7 @@
 import logging
 import urllib.request, urllib.parse, urllib.error
 
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.urls import reverse
 from django.http import HttpResponse
@@ -90,11 +91,17 @@ def dashboard_course(request):
 
     view_context = {
         'allowed': allowed,
-        'no_tools_allowed': no_tools_allowed}
+        'no_tools_allowed': no_tools_allowed,
+        'build_info': settings.BUILD_INFO,
+        }   
     if no_tools_allowed:
         view_context['custom_error_title'] = 'Not available'
         view_context['custom_error_message'] = \
             "You do not currently have access to any of the tools available " \
             "in this view. If you think you should have access, please " \
             "use \"Help\" to contact Canvas support from Harvard."
-    return render(request, 'canvas_manage_course/dashboard_course.html', view_context)
+    return render(
+        request, 
+        'canvas_manage_course/dashboard_course.html', 
+        view_context
+    )


### PR DESCRIPTION
- Added build info to Canvas Manage Course LTI
- Deployed on QA, build_info comment should be found under <main>
- Updated OracleDB dependency to use oracledb instead of cx-Oracle for local development

Refers to Subtask TLT-4494