### PR TITLE
TLT-4300: Create sections/enrollments in the DB

### DIFF
--- a/canvas_manage_course/requirements/base.txt
+++ b/canvas_manage_course/requirements/base.txt
@@ -15,7 +15,7 @@ django-watchman==1.3.0
 splunk_handler==3.0.0
 python-json-logger==2.0.2
 
-canvas_python_sdk @ git+ssh://git@github.com/Harvard-University-iCommons/canvas_python_sdk.git@patricktonne/update-param-in-create-section
+canvas_python_sdk @ git+ssh://git@github.com/Harvard-University-iCommons/canvas_python_sdk.git@v1.4.4
 
 django-auth-lti @ git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.1.0
 django-icommons-common @ git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v2.6

--- a/canvas_manage_course/requirements/base.txt
+++ b/canvas_manage_course/requirements/base.txt
@@ -15,7 +15,7 @@ django-watchman==1.3.0
 splunk_handler==3.0.0
 python-json-logger==2.0.2
 
-canvas_python_sdk @ git+ssh://git@github.com/Harvard-University-iCommons/canvas_python_sdk.git@v1.4.3
+canvas_python_sdk @ git+ssh://git@github.com/Harvard-University-iCommons/canvas_python_sdk.git@patricktonne/update-param-in-create-section
 
 django-auth-lti @ git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.1.0
 django-icommons-common @ git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v2.6

--- a/canvas_manage_course/settings/local.py
+++ b/canvas_manage_course/settings/local.py
@@ -1,18 +1,21 @@
 import sys
+
 import oracledb
+
 oracledb.version = "8.3.0"
 sys.modules["cx_Oracle"] = oracledb
+from logging.config import dictConfig
+
 import cx_Oracle
 
 from .base import *
-from logging.config import dictConfig
 
 ALLOWED_HOSTS = ['*']
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 INSTALLED_APPS += ['debug_toolbar', 'django_extensions']
-MIDDLEWARE += ['debug_toolbar.middleware.DebugToolbarMiddleware']
+# MIDDLEWARE += ['debug_toolbar.middleware.DebugToolbarMiddleware']
 
 # For Django Debug Toolbar:
 INTERNAL_IPS = ('127.0.0.1', '10.0.2.2',)

--- a/manage_sections/static/manage_sections/js/section_details.js
+++ b/manage_sections/static/manage_sections/js/section_details.js
@@ -39,7 +39,7 @@ $(document).ready(function() {
         $.get(userlistURL, function( data ) {
             $('#sectionUsers').html( data );
             updateSectionUserCountDisplay();
-            //call the pagination plugin after the data has been added   
+            //call the pagination plugin after the data has been added
             $('#people-list').alphabetPagination();
             paneHeight();
             // Tooltip message for when removing a user
@@ -47,7 +47,7 @@ $(document).ready(function() {
             $("#people-list").on('click', '.icon-removeUser', removeUser);
         })
         .done(function(){
-            //checking for msgCSS and msgTxt controls the displaying from showing when successfully 
+            //checking for msgCSS and msgTxt controls the displaying from showing when successfully
             //removing users from a section
             if ( !(typeof msgEleId === 'undefined' || typeof msgCSS === 'undefined' || typeof msgTxt === 'undefined') ) {
                 $('li' + msgEleId).removeClass('hidden').html(messageHTML(msgCSS, msgTxt));
@@ -56,12 +56,12 @@ $(document).ready(function() {
     }
 
     function loadSectionClassList(msgEleId, msgCSS, msgTxt) {
-        $.get(classlistURL, function( data ) {     
+        $.get(classlistURL, function( data ) {
             $('#fullClassList').html( data );
             // Reset selection count
             updateSelectionCountDisplay();
             $('.btn.add-selected-users').prop('disabled', true);
-            // Call the pagination plugin after the data has been added   
+            // Call the pagination plugin after the data has been added
             $('#people-in-course').alphabetPagination();
             paneHeight();
 
@@ -71,7 +71,7 @@ $(document).ready(function() {
             });
         })
         .done(function(){
-            //checking for msgCSS and msgTxt controls the displaying from showing when successfully 
+            //checking for msgCSS and msgTxt controls the displaying from showing when successfully
             //removing users from a section
             if ( !(typeof msgEleId === 'undefined' || typeof msgCSS === 'undefined' || typeof msgTxt === 'undefined') )
                 $('li' + msgEleId).removeClass('hidden').html(messageHTML(msgCSS, msgTxt));
@@ -125,16 +125,18 @@ $(document).ready(function() {
 
         $('#addUsers').show();
     }
-        
+
     function removeUser(e) {
         // Prevent the anchor from making the page jump
         e.preventDefault();
         var $removeUserBtn = $(this);
         var roleLabel = $removeUserBtn.attr('data-enrollment_role_label');
+        var roleId = $removeUserBtn.attr('data-enrollment_role_id');
+        var userId = $removeUserBtn.attr('data-user_id');
         var userLine = $(this).closest("li");
         var userName = $removeUserBtn.attr('data-user_name');
         $('#confirmDelUser .modal-body').html('Remove ' + userName + ' from this section?');
-        
+
         var msgTxt, msgCSS, msgEleId;
 
         var $modal = $('#confirmDelUser').modal({ keyboard:false });
@@ -142,11 +144,14 @@ $(document).ready(function() {
             //disable the delete popup buttons so the user is not abel to double click
             $('#confirmDelUser button').attr('disabled', 'disabled');
             $.ajax({
-                url : rmFromSectionURL, 
+                url : rmFromSectionURL,
                 type : "POST",
                 data : {
                     user_section_id : $removeUserBtn.attr("data-enrollee-id"),
-                    section_id: $('main').data('section_id')
+                    section_id: $('main').data('section_id'),
+                    sis_section_id: $('main').data('sis_section_id'),
+                    role_id: roleId,
+                    user_id: userId
                 }
             })
             .always(function(xhrOrData){
@@ -194,7 +199,7 @@ $(document).ready(function() {
             var $checkbox = $(this);
             userLines.push($checkbox.parent());
             usersToAdd.push({
-                enrollment_user_id: $checkbox.attr('data-user_id'), 
+                enrollment_user_id: $checkbox.attr('data-user_id'),
                 enrollment_role_id: $checkbox.attr('data-enrollment_role_id'),
                 enrollment_type: $checkbox.attr('data-enrollment_type')
             });
@@ -206,10 +211,12 @@ $(document).ready(function() {
         $addSelectedBtn.find('i').removeClass('fa-plus').addClass('fa-spinner fa-spin');
         var msgTxt, msgCSS, msgEleId;
         $.ajax({
-            url : addToSectionURL, 
+            url : addToSectionURL,
             type : "POST",
             data: JSON.stringify({
                 section_id: $('main').data('section_id'),
+                sis_section_id: $('main').data('sis_section_id'),
+                section_name: $('main').data('section_name'),
                 users_to_add: usersToAdd
             }),
             dataType: 'json',

--- a/manage_sections/templates/manage_sections/_enrollments_list_by_name.html
+++ b/manage_sections/templates/manage_sections/_enrollments_list_by_name.html
@@ -20,14 +20,14 @@
 </li>
 <li id="{{ msgID }}" class="message-holder list-group-item hidden"></li>
 {% for enrollment_by_name in enrollments_by_name %}
-    {% for enrollee in enrollment_by_name.list %} 
+    {% for enrollee in enrollment_by_name.list %}
         <li class="list-group-item list-student {{ enrollment_by_name.grouper|lower }}">
             {% if allow_add %}
                 <input type="checkbox" class="add-user" id="{{enrollee.user.id}}"
-                data-course_id="{{ enrollee.course_id }}" 
-                data-course_section_id="{{ enrollee.course_section_id }}" 
+                data-course_id="{{ enrollee.course_id }}"
+                data-course_section_id="{{ enrollee.course_section_id }}"
                 data-sis_course_id="{{enrollee.sis_course_id}}"
-                data-user_id="{{enrollee.user.id}}" 
+                data-user_id="{{enrollee.user.id}}"
                 data-enrollment_role="{{enrollee.role}}"
                 data-enrollment_role_id="{{enrollee.role_id}}"
                 data-enrollment_role_label="{{enrollee.role_label}}"
@@ -38,6 +38,7 @@
 
             {% if allow_delete %}
                 <a href="#" class="remover icon-removeUser" id="{{enrollee.id}}"
+                   data-user_id="{{enrollee.user.id}}"
                    data-enrollee-id="{{enrollee.id}}"
                    data-enrollment_role_id="{{enrollee.role_id}}"
                    data-enrollment_role_label="{{enrollee.role_label}}"

--- a/manage_sections/templates/manage_sections/_section_classlist.html
+++ b/manage_sections/templates/manage_sections/_section_classlist.html
@@ -1,6 +1,6 @@
 {% if enrollments %}
     <ul id="people-in-course" class="list-group list-section">
-        {% include "manage_sections/_enrollments_list_by_name.html" with allow_add=allow_edit section_id=section_id msgID='message-fullClassList'%}
+        {% include "manage_sections/_enrollments_list_by_name.html" with allow_add=allow_edit section_id=section_id sis_section_id=sis_section_id msgID='message-fullClassList'%}
     </ul>
 {% else %}
     <div class="jumbotron jumbotron-lti-emptySection">

--- a/manage_sections/templates/manage_sections/section_details.html
+++ b/manage_sections/templates/manage_sections/section_details.html
@@ -18,14 +18,14 @@
 
 {% block content %}
 <div class="container">
-    <main data-section_id="{{ section_id }}">
+    <main data-section_id="{{ section_id }}" data-sis_section_id="{{ sis_section_id }}" data-section_name="{{ section_name }}">
         <div class="row row-lti col-md-8 lti-section">
             <div id="pane-container">
                 <div id="updateOverlay" class="hide"></div>
                 {% if allow_edit %}
                     <a id="addUsers" class="pull-right action-link" href="#"><i class="fa fa-plus"></i> Add users to section</a>
                 {% endif %}
-                
+
                 <div id="pane-left">
                    {{section_name}}: <span class="enroll_count"></span> user<span class="enroll_count_pluralize"></span>
                    <div id="sectionUsers">

--- a/manage_sections/templates/manage_sections/section_list.html
+++ b/manage_sections/templates/manage_sections/section_list.html
@@ -1,14 +1,14 @@
-<li id="section-{{section.id}}" class="list-group-item courseSection" data-section-id="{{section.id}}">
+<li id="section-{{section.id}}" class="list-group-item courseSection" data-sis-section-id="{{section.sis_section_id}}" data-section-id="{{section.id}}">
     <div class="deleteMenu">
     {% if section.registrar_section_flag %}
         <a href="#" class="disable-delete lti-tooltip" rel="tooltip" data-toggle="tooltip" title="You can't delete sections that have been created outside of Canvas" data-original-title="You can't delete sections that have been created outside of Canvas"><i class="fa fa-trash-o"></i></a>
     {% else %}
-        <a href="{% url 'manage_sections:remove_section' section_id=section.id  %}" class="remove_data lti-tooltip" rel="tooltip" data-toggle="tooltip" title="Delete section" data-original-title="Delete section">
+        <a href="{% url 'manage_sections:remove_section' section_id=section.id  sis_section_id=section.sis_section_id %}" class="remove_data lti-tooltip" rel="tooltip" data-toggle="tooltip" title="Delete section" data-original-title="Delete section">
             <i class="fa fa-trash-o"></i><span class="sr-only">Delete Section</span>
         </a>
     {% endif %}
     </div>
-    <a class="listNav-item showSection" href="{% url 'manage_sections:section_details' section_id=section.id %}">
+    <a class="listNav-item showSection" href="{% url 'manage_sections:section_details' section_id=section.id sis_section_id=section.sis_section_id %}">
         <span class="sectionName">{{ section.name }}</span>
         {% if section.enrollment_count == 'n/a' %}
             (enrollee count not available)
@@ -20,7 +20,7 @@
     {% if section.registrar_section_flag %}
         <a href="#" class="disable-delete lti-tooltip" rel="tooltip" data-toggle="tooltip" title="You can't edit sections that have been created outside of Canvas" data-original-title="You can't edit sections that have been created outside of Canvas"><i class="fa fa-pencil"></i><span class="sr-only">Edit</span></a>
     {% else %}
-        <a href="{% url 'manage_sections:edit_section' section_id=section.id %}" class="editSection lti-tooltip" rel="tooltip" data-toggle="tooltip" title="Edit section name" data-original-title="Edit section name"><i class="fa fa-pencil"></i><span class="sr-only">Edit</span></a>
+        <a href="{% url 'manage_sections:edit_section' sis_section_id=section.sis_section_id section_id=section.id %}" class="editSection lti-tooltip" rel="tooltip" data-toggle="tooltip" title="Edit section name" data-original-title="Edit section name"><i class="fa fa-pencil"></i><span class="sr-only">Edit</span></a>
     {% endif %}
     </div>
 </li>

--- a/manage_sections/templates/manage_sections/sis_enrollment_sections.html
+++ b/manage_sections/templates/manage_sections/sis_enrollment_sections.html
@@ -1,5 +1,5 @@
 <li id="{{ section.id }}" class="">
-    <a class="main-sis-section" href="{% url 'manage_sections:section_details' section_id=section.id %}">
+    <a class="main-sis-section" href="{% url 'manage_sections:section_details' section_id=section.id sis_section_id=section.sis_section_id %}">
         {{ section.name }}
         {% if section.enrollment_count == 'n/a' %}
             (enrollee count not available)

--- a/manage_sections/urls.py
+++ b/manage_sections/urls.py
@@ -2,16 +2,15 @@ from django.urls import path, re_path
 
 from manage_sections import views
 
-
 urlpatterns = [
     path('create_section_form', views.create_section_form, name='create_section_form'),
     path('create_section', views.create_section, name='create_section'),
-    re_path(r'^edit_section/(?P<section_id>\d+)$', views.edit_section, name='edit_section'),
-    re_path(r'^section_details/(?P<section_id>\d+)$', views.section_details, name='section_details'),
-    re_path(r'^remove_section/(?P<section_id>\d+)$', views.remove_section, name='remove_section'),
+    path('edit_section/<str:sis_section_id>/<int:section_id>', views.edit_section, name='edit_section'),
+    path('section_details/<str:sis_section_id>/<int:section_id>', views.section_details, name='section_details'),
+    path('remove_section/<str:sis_section_id>/<int:section_id>', views.remove_section, name='remove_section'),
     path('remove_from_section', views.remove_from_section, name='remove_from_section'),
     re_path(r'^sections/(?P<section_id>\d+)/classlist$', views.section_class_list, name='section_class_list'),
-    re_path(r'^section_user_list/(?P<section_id>\d+)$', views.section_user_list, name='section_user_list'),
+    path('section_user_list/<int:section_id>', views.section_user_list, name='section_user_list'),
     path('add_to_section', views.add_to_section, name='add_to_section'),
     path('monitor', views.MonitorResponseView.as_view()),
 ]

--- a/manage_sections/utils.py
+++ b/manage_sections/utils.py
@@ -9,6 +9,15 @@ from canvas_sdk.methods import (
     enrollments as canvas_api_enrollments
 )
 from canvas_sdk.exceptions import CanvasAPIError
+from canvas_sdk.methods import enrollments as canvas_api_enrollments
+from canvas_sdk.methods import sections
+from django.conf import settings
+from icommons_common.canvas_api.helpers import \
+    courses as canvas_api_helper_courses
+from icommons_common.canvas_api.helpers import \
+    enrollments as canvas_api_helper_enrollments
+from icommons_common.canvas_api.helpers import \
+    sections as canvas_api_helper_sections
 from icommons_common.canvas_utils import SessionInactivityExpirationRC
 from icommons_common.models import CourseInstance
 from canvas_api.helpers import (
@@ -203,3 +212,26 @@ def delete_enrollments(enrollments, course_id):
     canvas_api_helper_sections.delete_cache(course_id)
 
     return (deleted_enrollments, is_empty)
+
+
+def create_db_section(course_instance: CourseInstance, section_name: str):
+    try:
+        db_course_section = CourseInstance(
+            cs_class_type='N',
+            parent_course_instance_id=course_instance.course_instance_id,
+            course_id=course_instance.course_id,
+            term=course_instance.term,
+            source='managecrs',
+            sync_to_canvas = 1,
+            title = section_name.strip(),
+            short_title = section_name.strip(),
+        )
+        db_course_section.save()
+    except Exception as e:
+        logger.exception(
+            f'Unexpected error while creating section for '
+            f'course_instance_id:{course_instance.course_instance_id}',
+            extra={'error': e},
+        )
+        raise
+    return db_course_section

--- a/manage_sections/utils.py
+++ b/manage_sections/utils.py
@@ -2,12 +2,9 @@ import functools
 import logging
 import re
 
-from django.conf import settings
-
-from canvas_sdk.methods import (
-    sections,
-    enrollments as canvas_api_enrollments
-)
+from canvas_api.helpers import courses as canvas_api_helper_courses
+from canvas_api.helpers import enrollments as canvas_api_helper_enrollments
+from canvas_api.helpers import sections as canvas_api_helper_sections
 from canvas_sdk.exceptions import CanvasAPIError
 from canvas_sdk.methods import enrollments as canvas_api_enrollments
 from canvas_sdk.methods import sections
@@ -20,12 +17,6 @@ from icommons_common.canvas_api.helpers import \
     sections as canvas_api_helper_sections
 from icommons_common.canvas_utils import SessionInactivityExpirationRC
 from icommons_common.models import CourseInstance
-from canvas_api.helpers import (
-    courses as canvas_api_helper_courses,
-    enrollments as canvas_api_helper_enrollments,
-    sections as canvas_api_helper_sections
-)
-
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +71,7 @@ def is_enrollment_section(sis_section_id):
 def is_sis_section(sis_section_id):
     """
     Check if the sis_section_id exists in the CourseInstance table.
-    If it does, it is an sis section.
+    If it does (and the source isn't 'managecrs') it is an sis section.
     :param sis_section_id:
     :return boolean:
     """
@@ -88,7 +79,7 @@ def is_sis_section(sis_section_id):
         if sis_section_id.isdigit():
             try:
                 ci = CourseInstance.objects.get(course_instance_id=int(sis_section_id))
-                if ci:
+                if ci and ci.source != 'managecrs':
                     return True
             except (CourseInstance.DoesNotExist, CourseInstance.MultipleObjectsReturned, ValueError) as e:
                 return False

--- a/manage_sections/utils.py
+++ b/manage_sections/utils.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 import re
 
@@ -99,15 +100,34 @@ def is_credit_status_section(sis_section_id):
     return False
 
 
-def is_editable_section(section):
+@functools.singledispatch
+def is_editable_section(arg):
+    raise NotImplementedError(f'Unsupported type: {type(arg)}')
+
+
+@is_editable_section.register
+def is_editable_section_str(section: str):
     """
     This is a helper method to check if the section is editable. If it's a primary section or a
     registrar section it shouldn't be editable.
     Set to True if it is a primary/registrar section, set to False if it is not
     """
-    sis_section_id = section.get('sis_section_id')
-    if is_sis_section(sis_section_id) or is_credit_status_section(sis_section_id):
+    if is_sis_section(section) or is_credit_status_section(section):
         return False
+
+    return True
+
+
+@is_editable_section.register
+def is_editable_section_dict(section: dict):
+    """
+    This is a helper method to check if the section is editable. If it's a primary section or a
+    registrar section it shouldn't be editable.
+    Set to True if it is a primary/registrar section, set to False if it is not
+    """
+    if section.get('sis_section_id', ''):
+        if is_sis_section(section['sis_section_id']) or is_credit_status_section(section['sis_section_id']):
+            return False
 
     return True
 

--- a/manage_sections/views.py
+++ b/manage_sections/views.py
@@ -3,6 +3,9 @@ import logging
 import re
 import time
 
+from canvas_api.helpers import courses as canvas_api_helper_courses
+from canvas_api.helpers import enrollments as canvas_api_helper_enrollments
+from canvas_api.helpers import sections as canvas_api_helper_sections
 from canvas_sdk.exceptions import CanvasAPIError
 from canvas_sdk.methods import enrollments as canvas_api_enrollments
 from canvas_sdk.methods import users as canvas_api_users
@@ -11,16 +14,6 @@ from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
 from django.shortcuts import render
 from django.views.decorators.http import require_http_methods, require_safe
-
-from canvas_sdk.methods import enrollments as canvas_api_enrollments
-from canvas_sdk.exceptions import CanvasAPIError
-
-from icommons_common.models import Person
-from icommons_common.monitor.views import BaseMonitorResponseView
-from canvas_api.helpers import (
-    courses as canvas_api_helper_courses,
-    enrollments as canvas_api_helper_enrollments,
-    sections as canvas_api_helper_sections
 from icommons_common.models import (CourseEnrollee, CourseGuest,
                                     CourseInstance, CourseStaff, Person,
                                     UserRole)
@@ -213,7 +206,7 @@ def create_section(request):
         logger.exception(f'Exception in create_section: {e}')
         return render(request, 'manage_sections/error.html', status=500)
 
-    canvas_course_section = canvas_api_helper_sections.create_section(canvas_course_id, section_name.strip(), course_section_sis_section_id=created_db_section.course_instance_id)
+    canvas_course_section = canvas_api_helper_sections.create_section(canvas_course_id, section_name.strip(), sis_section_id=created_db_section.course_instance_id)
 
     # Append section count to course_section object so the badge will appear correctly. Setting to zero
     # for newly created section.
@@ -535,8 +528,7 @@ def remove_from_section(request):
         table = CourseGuest
 
     try:
-        enrollment = table.objects.get(course_instance_id=int(sis_section_id), user_id=int(huid), role=db_role).delete()
-        enrollment.save()
+        table.objects.get(course_instance_id=int(sis_section_id), user_id=int(huid), role=db_role).delete()
     except Exception as e:
         message = f"Failed to retrieve record from {table} from DB: {e}"
         logger.exception(message)

--- a/manage_sections/views.py
+++ b/manage_sections/views.py
@@ -3,6 +3,9 @@ import logging
 import re
 import time
 
+from canvas_sdk.exceptions import CanvasAPIError
+from canvas_sdk.methods import enrollments as canvas_api_enrollments
+from canvas_sdk.methods import users as canvas_api_users
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
@@ -18,19 +21,16 @@ from canvas_api.helpers import (
     courses as canvas_api_helper_courses,
     enrollments as canvas_api_helper_enrollments,
     sections as canvas_api_helper_sections
-)
+from icommons_common.models import (CourseEnrollee, CourseGuest,
+                                    CourseInstance, CourseStaff, Person,
+                                    UserRole)
+from icommons_common.monitor.views import BaseMonitorResponseView
 from lti_school_permissions.decorators import lti_permission_required
 
-from .utils import (
-    SDK_CONTEXT,
-    unique_enrollments_not_in_section_filter,
-    is_editable_section,
-    is_enrollment_section,
-    is_sis_section,
-    is_credit_status_section,
-    delete_enrollments
-)
-
+from .utils import (SDK_CONTEXT, create_db_section, delete_enrollments,
+                    is_credit_status_section, is_editable_section,
+                    is_enrollment_section, is_sis_section,
+                    unique_enrollments_not_in_section_filter)
 
 logger = logging.getLogger(__name__)
 
@@ -157,6 +157,7 @@ def create_section_form(request):
                 'No sections found for Canvas course %s' % canvas_course_id
             )
             return render(request, 'manage_sections/error.html', status=500)
+
         for section in canvas_sections:
             if 'total_students' in section:
                 section['enrollment_count'] = section['total_students']
@@ -193,28 +194,38 @@ def create_section_form(request):
 def create_section(request):
     canvas_course_id = request.LTI['custom_canvas_course_id']
     section_name = request.POST.get('section_name_input')
+    course_instance_id = request.LTI['lis_course_offering_sourcedid']
 
     # check to see if the textbox is empty
     if not section_name or not section_name.strip():
         return render(request, 'manage_sections/create_section_form.html', {}, status=400)
 
-    course_section = canvas_api_helper_sections.create_section(canvas_course_id, section_name.strip())
+    # get parent course instance
+    try:
+        parent_course_instance = CourseInstance.objects.get(course_instance_id=course_instance_id)
+    except Exception as e:
+        logger.exception(f'Exception in edit_section: {e}')
+        return render(request, 'manage_sections/error.html', status=500)
 
-    # if section creation failed for whatever reason, return error status.
-    if not course_section:
-        return render(request, 'manage_sections/create_section_form.html', {'section': course_section}, status=500)
+    try:
+        created_db_section = create_db_section(parent_course_instance, section_name)
+    except Exception as e:
+        logger.exception(f'Exception in create_section: {e}')
+        return render(request, 'manage_sections/error.html', status=500)
+
+    canvas_course_section = canvas_api_helper_sections.create_section(canvas_course_id, section_name.strip(), course_section_sis_section_id=created_db_section.course_instance_id)
 
     # Append section count to course_section object so the badge will appear correctly. Setting to zero
     # for newly created section.
-    course_section['enrollment_count'] = 0
+    canvas_course_section['enrollment_count'] = 0
 
-    return render(request, 'manage_sections/section_list.html', {'section': course_section})
+    return render(request, 'manage_sections/section_list.html', {'section': canvas_course_section})
 
 
 @login_required
 @lti_permission_required('manage_sections')
 @require_http_methods(['POST'])
-def edit_section(request, section_id):
+def edit_section(request, sis_section_id, section_id):
     canvas_course_id = request.LTI['custom_canvas_course_id']
     section_name = request.POST.get('section_name_input', '').strip()
     enrollment_count = request.POST.get('enrollment_count')
@@ -223,28 +234,36 @@ def edit_section(request, section_id):
     if not section_name:
         return render(request, 'manage_sections/create_section_form.html', {}, status=400)
 
-    # grab the section
-    try:
-        section = canvas_api_helper_sections.get_section(canvas_course_id, section_id)
-    except RuntimeError:
-        logger.exception(
-            'Unable to get section {} (course {}) from Canvas'.format(
-                section_id, canvas_course_id))
-        section = None
-    if not section:
-        message = 'Failed to retrieve section {} from course {}'.format(section_id, canvas_course_id)
-        logger.error(message)
-        return JsonResponse({'message': message}, status=500)
-
     # verify we should allow the edit
-    if not is_editable_section(section):
+    if not is_editable_section(sis_section_id):
         # send http status code 422=Unprocessable Entity
         return JsonResponse(
             {'message': 'Error: Registrar fed sections cannot be edited'},
             status=422
         )
 
-    # do the edit
+    # grab the section from the db
+    try:
+        section = CourseInstance.objects.get(course_instance_id=sis_section_id)
+    except Exception as e:
+        logger.exception(f'Exception in edit_section: {e}')
+        return render(request, 'manage_sections/error.html', status=500)
+
+    if not section:
+        message = 'Failed to retrieve section {} from course {}'.format(sis_section_id, canvas_course_id)
+        logger.error(message)
+        return JsonResponse({'message': message}, status=500)
+
+    # Make the edit in the DB
+    try:
+        section.title = section_name
+        section.short_title = section_name
+        section.save()
+    except Exception as e:
+        logger.exception(f'Exception in edit_section: {e}')
+        return render(request, 'manage_sections/create_section_form.html', {}, status=500)
+
+    # Now attempt the edit via Canvas API
     try:
         course_section = canvas_api_helper_sections.update_section(
             canvas_course_id, section_id, course_section_name=section_name
@@ -257,11 +276,6 @@ def edit_section(request, section_id):
         canvas_api_helper_courses.delete_cache(canvas_course_id=canvas_course_id)
         canvas_api_helper_enrollments.delete_cache(canvas_course_id)
 
-    # if section update failed for whatever reason, return error status.
-    if not course_section:
-        return render(request, 'manage_sections/create_section_form.html', {},
-                      status=500)
-
     # Append section count to course_section object so the badge will appear
     # correctly. Setting to zero for newly created section.
     course_section['enrollment_count'] = enrollment_count or 0
@@ -273,7 +287,7 @@ def edit_section(request, section_id):
 @login_required
 @lti_permission_required('manage_sections')
 @require_http_methods(['GET'])
-def section_details(request, section_id):
+def section_details(request, section_id, sis_section_id):
     canvas_course_id = request.LTI['custom_canvas_course_id']
     section = canvas_api_helper_sections.get_section(canvas_course_id, section_id)
     if not section:
@@ -285,6 +299,7 @@ def section_details(request, section_id):
     return render(request, 'manage_sections/section_details.html', {
         'section_id': section_id,
         'section_name': section['name'],
+        'sis_section_id': sis_section_id,
         'allow_edit': is_editable_section(section)
     })
 
@@ -311,20 +326,40 @@ def section_user_list(request, section_id):
 @login_required
 @lti_permission_required('manage_sections')
 @require_http_methods(['POST'])
-def remove_section(request, section_id):
+def remove_section(request, sis_section_id, section_id):
     canvas_course_id = request.LTI['custom_canvas_course_id']
-    section = canvas_api_helper_sections.get_section(canvas_course_id, section_id)
-    if not section:
+
+    canvas_section = canvas_api_helper_sections.get_section(canvas_course_id, section_id)
+    if not canvas_section:
         message = "Failed to retrieve section %s from course %s" % (section_id, canvas_course_id)
         logger.error(message)
         return JsonResponse({'message': message}, status=500)
 
-    if not is_editable_section(section):
+    if not is_editable_section(canvas_section):
         # send http status code 422=Unprocessable Entity
         return JsonResponse(
             {'message': 'Error: Registrar fed sections cannot be deleted'},
             status=422
         )
+
+    # grab the section from the db
+    try:
+        db_section = CourseInstance.objects.get(course_instance_id=sis_section_id)
+        db_section.deleted = 1
+        db_section.sync_to_canvas = 0
+        db_section.save()
+    except Exception as e:
+        logger.exception(f'Exception in edit_section: {e}')
+        return render(request, 'manage_sections/error.html', status=500)
+
+    # Now check/delete enrollments
+    for table in (CourseEnrollee, CourseGuest, CourseStaff):
+        try:
+            enrollments = table.objects.filter(course_instance_id=sis_section_id).delete()
+        except Exception as e:
+            message = "Failed to retrieve section %s from course %s" % (section_id, canvas_course_id)
+            logger.error(message)
+            return JsonResponse({'message': message}, status=500)
 
     enrollments = canvas_api_enrollments.list_enrollments_sections(SDK_CONTEXT, section_id).json()
     if len(enrollments) > 0:
@@ -336,8 +371,8 @@ def remove_section(request, section_id):
                 status=500
             )
 
-    section = canvas_api_helper_sections.delete_section(canvas_course_id, section_id)
-    return JsonResponse(section)
+    canvas_section = canvas_api_helper_sections.delete_section(canvas_course_id, section_id)
+    return JsonResponse(canvas_section)
 
 
 @login_required
@@ -380,13 +415,62 @@ def add_to_section(request):
         canvas_course_id = request.LTI['custom_canvas_course_id']
         post_data = json.loads(request.body)
         section_id = post_data['section_id']
+        sis_section_id = post_data['sis_section_id']
         users_to_add = post_data['users_to_add']
     except KeyError:
         message = "Missing post parameters to add users to section_id %s" % request.body
         logger.exception(message)
         return JsonResponse({'success': False, 'message': message}, status=500)
 
+    # Map Canvas role to DB role
+    for user in users_to_add:
+        # The user is a student, but we have 5 roles that map to 90 in the DB, so
+        # select the one designated purely as Student
+        try:
+            if user['enrollment_role_id'] == '90':
+                db_role = UserRole.objects.get(role_id=0)
+            else:
+                db_role = UserRole.objects.get(canvas_role_id=user['enrollment_role_id'])
+        except Exception as e:
+            message = f"Failed to retrieve role {user['enrollment_role_id']} from DB: {e}"
+            logger.exception(message)
+            return JsonResponse({'success': False, 'message': message}, status=500)
+
+        # get the user's HUID from Canvas
+        try:
+            huid = canvas_api_users.get_user_profile(SDK_CONTEXT, user['enrollment_user_id']).json()['sis_user_id']
+        except Exception as e:
+            message = f"Failed to retrieve user {user['enrollment_user_id']} from Canvas: {e}"
+            logger.exception(message)
+            return JsonResponse({'success': False, 'message': message}, status=500)
+
+        if db_role.staff == '1':
+            table = CourseStaff
+        elif db_role.student == '1':
+            table = CourseEnrollee
+        else:
+            table = CourseGuest
+
+        try:
+            enrollment = table(
+                course_instance_id=sis_section_id,
+                user_id = huid,
+                role = db_role,
+                source='managecrs'
+            )
+            enrollment.save()
+        except Exception as e:
+            message = f"Failed to add user {user['enrollment_user_id']} to DB: {e}"
+            logger.exception(message)
+            return JsonResponse({'success': False, 'message': message}, status=500)
+
+    # Make a best-effort attempt to add the user to the section in Canvas.
+    # If this fails, we'll proceed anyway knowing that the feed will
+    # eventually add the user to the section
     failed_users = []
+    failed_users = []
+    for user in users_to_add:
+        failed_users = []
     for user in users_to_add:
         try:
             canvas_api_enrollments.enroll_user_sections(
@@ -398,7 +482,7 @@ def add_to_section(request):
                 enrollment_enrollment_state='active'
             )
         except (KeyError, CanvasAPIError):
-            logger.exception("Failed to add user to section %s %s", section_id, json.dumps(user))
+            logger.exception(f"Failed to add user to section {section_id} {json.dumps(user)}")
             failed_users.append(user)
     canvas_api_helper_courses.delete_cache(canvas_course_id=canvas_course_id)
     canvas_api_helper_enrollments.delete_cache(canvas_course_id)
@@ -417,9 +501,48 @@ def add_to_section(request):
 def remove_from_section(request):
     canvas_course_id = request.LTI['custom_canvas_course_id']
     user_section_id = request.POST.get('user_section_id')
+    sis_section_id = request.POST.get('sis_section_id')
     section_id = request.POST.get('section_id')
+    role_id = request.POST.get('role_id')
+    user_id = request.POST.get('user_id')
     if not user_section_id:
         return JsonResponse({'message': "Invalid user_section_id %s" % user_section_id}, status=500)
+
+    # Get HUID from Canvas
+    try:
+        huid = canvas_api_users.get_user_profile(SDK_CONTEXT, user_id).json()['sis_user_id']
+    except Exception as e:
+        message = f"Failed to retrieve user {user_id} from Canvas: {e}"
+        logger.exception(message)
+        return JsonResponse({'success': False, 'message': message}, status=500)
+
+    # There are 5 roles that map to 90 in the DB, so select the one designated purely as Student.
+    try:
+        if role_id == '90':
+            db_role = UserRole.objects.get(role_id=0)
+        else:
+            db_role = UserRole.objects.get(canvas_role_id=role_id)
+    except Exception as e:
+        message = f"Failed to retrieve role {user_id} from DB: {e}"
+        logger.exception(message)
+        return JsonResponse({'success': False, 'message': message}, status=500)
+
+    if db_role.staff == '1':
+        table = CourseStaff
+    elif db_role.student == '1':
+        table = CourseEnrollee
+    else:
+        table = CourseGuest
+
+    try:
+        enrollment = table.objects.get(course_instance_id=int(sis_section_id), user_id=int(huid), role=db_role).delete()
+        enrollment.save()
+    except Exception as e:
+        message = f"Failed to retrieve record from {table} from DB: {e}"
+        logger.exception(message)
+        return JsonResponse({'success': False, 'message': message}, status=500)
+
+    # Now delete from Canvas
     try:
         response = canvas_api_enrollments.conclude_enrollment(
             SDK_CONTEXT, canvas_course_id, user_section_id, 'delete'

--- a/manage_sections/views.py
+++ b/manage_sections/views.py
@@ -461,9 +461,6 @@ def add_to_section(request):
     # If this fails, we'll proceed anyway knowing that the feed will
     # eventually add the user to the section
     failed_users = []
-    failed_users = []
-    for user in users_to_add:
-        failed_users = []
     for user in users_to_add:
         try:
             canvas_api_enrollments.enroll_user_sections(


### PR DESCRIPTION
Depend on [#8](https://github.com/Harvard-University-iCommons/canvas_python_sdk/pull/8).

This PR updates the Manage Sections tool to create sections and enrollments in the corresponding tables in Coursemanager.

Previously, the tool operated by making the updates directly in Canvas via the API. Now, sections/enrollments are first added to the DB, then added to Canvas via a best-effort API attempt. If the Canvas API call fails, we still return a success message with the understanding that the feed will input that section/enrollment in < 5 minutes. However, if the DB insertion/update/deletion fails, the operation is considered a failure and will return an error message.

TODOs in follow-up stories:
- Right now, this branch does not function correctly when interacting with previously created sections via the old, currently in-place logic (e.g. a section that was created in a course last semester via this tool). This is because this branch relies on the presence of an `sis_section_id` that maps the Canvas section to the one in the DB (the `sis_section_id` is the `course_instance_id` of the newly created section). Sections created with the old logic will not have a DB record, and therefore not have a `sis_section_id`. There's a proposal made in [TLT-4510](https://jira.huit.harvard.edu/browse/TLT-4510) for a potential update to make things compatible, but other ideas are welcome.
- Described in [TLT-4507](https://jira.huit.harvard.edu/browse/TLT-4507), the Canvas feed updates the titles of manually created sections to conform to school specifications. We likely don't want this for sections created via this tool.

### Testing

Deployed to QA.

Due to the note above regarding backward-compatibility, the changes in this branch should be tested with a Canvas course that doesn't have stale data. For testing, I used this course: https://harvard.test.instructure.com/courses/133237/external_tools/97822