### PR TITLE
TLT-4512: reduce log level of enrollment lookup from `exception` to `warning`

### DIFF
--- a/manage_people/views.py
+++ b/manage_people/views.py
@@ -189,7 +189,7 @@ def get_enrolled_roles_for_user_ids(canvas_course_id, search_results_user_ids):
                 get_all_list_data(SDK_CONTEXT, enrollments.list_enrollments_courses, canvas_course_id, user_id=f'sis_user_id:{user_id}', per_page=100)
             )
         except:
-            logger.exception(f'Canvas API returned an error when searching for enrollments for {user_id}. That user may not exist in Canvas at all.')
+            logger.warning(f'Canvas API returned an error when searching for enrollments for {user_id}. That user may not exist in Canvas at all.')
     t1 = time.perf_counter()
     logger.debug(f'canvas_enrollments: {canvas_enrollments}')
     logger.debug(f'*** TIMING list_enrollments_courses took {t1 - t0} seconds')


### PR DESCRIPTION
Reduces the log level of an enrollment lookup within Manage People from `exception` to `warning` to reduce noise in the Django Errors Slack channel.