### PR TITLE
TLT-4451: handle deletion of section enrollee with non-HUID ID

### DIFF
--- a/manage_sections/views.py
+++ b/manage_sections/views.py
@@ -525,7 +525,7 @@ def remove_from_section(request):
         table = CourseGuest
 
     try:
-        table.objects.get(course_instance_id=int(sis_section_id), user_id=int(huid), role=db_role).delete()
+        table.objects.get(course_instance_id=int(sis_section_id), user_id=huid, role=db_role).delete()
     except Exception as e:
         message = f"Failed to retrieve enrollment record for section {sis_section_id} from DB: {e}"
         logger.exception(message)

--- a/manage_sections/views.py
+++ b/manage_sections/views.py
@@ -526,6 +526,7 @@ def remove_from_section(request):
 
     try:
         table.objects.get(course_instance_id=int(sis_section_id), user_id=huid, role=db_role).delete()
+        logger.debug(f'Successfully deleted user_id={huid}, role={db_role} from course_instance_id={int(sis_section_id)}')
     except Exception as e:
         message = f"Failed to retrieve enrollment record for section {sis_section_id} from DB: {e}"
         logger.exception(message)


### PR DESCRIPTION
Resolves [TLT-4451](https://at-harvard.atlassian.net/browse/TLT-4551).

This PR resolves a bug that prevents the deletion of section enrollees that were enrolled with a non-HUID ID.

The old implementation casted the `user_id` to an `int`, resulting in errors when the `user_id` was alphanumeric (e.g. an HKL). This PR removes that casting operation.

Deployed to dev/qa.
