### PR TITLE
TLT-4552: disable editing of legacy sections

### DIFF
--- a/manage_sections/templates/manage_sections/section_list.html
+++ b/manage_sections/templates/manage_sections/section_list.html
@@ -1,11 +1,13 @@
-<li id="section-{{section.id}}" class="list-group-item courseSection" data-sis-section-id="{{section.sis_section_id}}" data-section-id="{{section.id}}">
+<li id="section-{{section.id}}" class="list-group-item courseSection" data-sis-section-id="{{section.sis_section_id|default_if_none:""}}" data-section-id="{{section.id}}">
     <div class="deleteMenu">
     {% if section.registrar_section_flag %}
         <a href="#" class="disable-delete lti-tooltip" rel="tooltip" data-toggle="tooltip" title="You can't delete sections that have been created outside of Canvas" data-original-title="You can't delete sections that have been created outside of Canvas"><i class="fa fa-trash-o"></i></a>
-    {% else %}
+    {% elif section.sis_section_id %}
         <a href="{% url 'manage_sections:remove_section' section_id=section.id  sis_section_id=section.sis_section_id %}" class="remove_data lti-tooltip" rel="tooltip" data-toggle="tooltip" title="Delete section" data-original-title="Delete section">
             <i class="fa fa-trash-o"></i><span class="sr-only">Delete Section</span>
         </a>
+    {% else %}
+        <a href="#" class="disable-delete lti-tooltip" rel="tooltip" data-toggle="tooltip" title="This legacy section cannot be deleted" data-original-title="This legacy section cannot be deleted"><i class="fa fa-trash-o"></i></a>
     {% endif %}
     </div>
     <a class="listNav-item showSection" href="{% url 'manage_sections:section_details' section_id=section.id sis_section_id=section.sis_section_id %}">
@@ -19,8 +21,10 @@
     <div class="editMenu">
     {% if section.registrar_section_flag %}
         <a href="#" class="disable-delete lti-tooltip" rel="tooltip" data-toggle="tooltip" title="You can't edit sections that have been created outside of Canvas" data-original-title="You can't edit sections that have been created outside of Canvas"><i class="fa fa-pencil"></i><span class="sr-only">Edit</span></a>
-    {% else %}
+    {% elif section.sis_section_id %}
         <a href="{% url 'manage_sections:edit_section' sis_section_id=section.sis_section_id section_id=section.id %}" class="editSection lti-tooltip" rel="tooltip" data-toggle="tooltip" title="Edit section name" data-original-title="Edit section name"><i class="fa fa-pencil"></i><span class="sr-only">Edit</span></a>
+    {% else %}
+        <a href="#" class="disable-delete lti-tooltip" rel="tooltip" data-toggle="tooltip" title="This legacy section cannot be edited" data-original-title="This legacy section cannot be edited"><i class="fa fa-pencil"></i><span class="sr-only">Edit</span></a>
     {% endif %}
     </div>
 </li>

--- a/manage_sections/utils.py
+++ b/manage_sections/utils.py
@@ -112,6 +112,8 @@ def is_editable_section_str(section: str):
     registrar section it shouldn't be editable.
     Set to True if it is a primary/registrar section, set to False if it is not
     """
+    if not section:
+        return False
     if is_sis_section(section) or is_credit_status_section(section):
         return False
 
@@ -125,9 +127,11 @@ def is_editable_section_dict(section: dict):
     registrar section it shouldn't be editable.
     Set to True if it is a primary/registrar section, set to False if it is not
     """
-    if section.get('sis_section_id', ''):
-        if is_sis_section(section['sis_section_id']) or is_credit_status_section(section['sis_section_id']):
-            return False
+    sis_section_id = section.get('sis_section_id')
+    if not sis_section_id:
+        return False
+    if is_sis_section(sis_section_id) or is_credit_status_section(sis_section_id):
+        return False
 
     return True
 


### PR DESCRIPTION
This PR disables the editing of sections without an `sis_section_id`. For those sections, this prevents:
- Deletion of the section
- Updating of the section's title
- Deletion of existing enrollments within the section
- Adding new users to to the section.

All sections (either fed from the registrar or created via Manage Sections) will have an `sis_section_id` moving forward, so this update only affects sections created by the old version of this tool. The backfilling process will create `sis_section_ids` for sections from within the past two years (through 2021) and for those associated with an Ongoing term. All other sections will not be editable.

### Testing

As an example, here's a section that has deletion and title editing capabilities removed:

![Screen Shot 2023-11-17 at 11 09 21 AM](https://github.com/Harvard-University-iCommons/canvas_manage_course/assets/43320443/97c739f1-8988-480c-84b9-d72b5538ef78)

and here's a section with those capabilities enabled:

![Screen Shot 2023-11-17 at 11 09 29 AM](https://github.com/Harvard-University-iCommons/canvas_manage_course/assets/43320443/3ee1a072-04a3-4423-8d44-90d887419562)

Deployed to DEV and QA.

