### PR TITLE
Task/haydn9000/tlt 4550/add a loading indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Canvas Manage Course
+![Static Badge](https://img.shields.io/badge/Python-v3.10-lavender?logo=python)
 
 This project provides a collection of utilies used to administer Harvard Academic Technology's instance of Canvas at the course level. The project is an LTI tool, i.e. installed via LTI.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Canvas Manage Course
 ![Static Badge](https://img.shields.io/badge/Python-v3.10-lavender?logo=python)
+![GitHub tag (with filter)](https://img.shields.io/github/v/tag/Harvard-University-iCommons/canvas_manage_course?label=Latest%20tag)
 
 This project provides a collection of utilies used to administer Harvard Academic Technology's instance of Canvas at the course level. The project is an LTI tool, i.e. installed via LTI.
 

--- a/canvas_manage_course/settings/base.py
+++ b/canvas_manage_course/settings/base.py
@@ -121,6 +121,8 @@ DATABASES = {
     }
 }
 
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
 # Cache
 # https://docs.djangoproject.com/en/1.8/ref/settings/#std:setting-CACHES
 

--- a/manage_sections/templates/manage_sections/create_section_form.html
+++ b/manage_sections/templates/manage_sections/create_section_form.html
@@ -28,19 +28,23 @@
         <p><small>
           These sections are fed from the Registrar's office.
         </small></p>
-        <ul class="">
-            {%  for section in sisenrollmentsections %}
-                {% include "manage_sections/sis_enrollment_sections.html" with data=section %}
-            {% endfor %}
-        </ul>
+        <div class="sections-list">
+            <ul class="">
+                {%  for section in sisenrollmentsections %}
+                    {% include "manage_sections/sis_enrollment_sections.html" with data=section %}
+                {% endfor %}
+            </ul>
+        </div>
         <button id="addSection" class="btn btn-primary"><i class="fa fa-plus"></i> Add A Section</button>
         <h3>Section(s):</h3>
-        <ul id="sectionsMenu" class="listNav list-group list-unstyled">
+        <div class="sections-list">
+            <ul id="sectionsMenu" class="listNav list-group list-unstyled">
 
-            {%  for section in sections %}
-                {% include "manage_sections/section_list.html" with data=section %}
-            {% endfor %}
-        </ul>
+                {%  for section in sections %}
+                    {% include "manage_sections/section_list.html" with data=section %}
+                {% endfor %}
+            </ul>
+        </div>
         <p><span style="font-size: larger;">*</span> does not include teaching staff enrollments</p>
 
         <form class="hide" action="{% url 'manage_sections:create_section' %}" method="post" id="formId">
@@ -99,6 +103,11 @@ $(document).ready(function(){
         container: 'body'
     });
 
+    // Add event listener to 'main-sis-section' elements to display a spinner upon click.
+    $('.main-sis-section').on('click', function (event) {
+        // Append loading content indicator after the clicked link.
+        $(this).parent('li').append('<span> Loadind... <i class="fa-li fa fa-spinner fa-spin"></i></span>');
+    });
 
     //the sections menu
     var $menu = $('#sectionsMenu');

--- a/manage_sections/templates/manage_sections/create_section_form.html
+++ b/manage_sections/templates/manage_sections/create_section_form.html
@@ -104,10 +104,16 @@ $(document).ready(function(){
         container: 'body'
     });
 
-    // Add event listener to 'main-sis-section' elements to display a spinner upon click.
-    $('.main-sis-section').on('click', function (event) {
-        // Append loading content indicator after the clicked link.
-        $(this).parent('li').append(' Loading... <i class="fa fa-spinner fa-spin" aria-hidden="true"></i>');
+    // Add event listener to 'main-sis-section' and 'section-list' elements to display a spinner upon click.
+    $('.main-sis-section, .section-list').on('click', function (event) {
+        const spinner = ' Loading... <i class="fa fa-spinner fa-spin" aria-hidden="true"></i>'
+
+        // Append loading content (spinner) indicator after the clicked link.
+        if ($(this).hasClass('main-sis-section')) {
+            $(this).closest('li').append(`<span>&emsp;${spinner}</span>`);
+        } else if ($(this).hasClass('section-list')) {
+            $(this).closest('div').append(`<span class="listNav-item">${spinner}<span style="font-size: larger;"></span></span>`);
+        }
     });
 
     //the sections menu

--- a/manage_sections/templates/manage_sections/create_section_form.html
+++ b/manage_sections/templates/manage_sections/create_section_form.html
@@ -465,6 +465,12 @@ $(document).ready(function(){
         const removeUrl = $(this).data('url');
         const sectionId = $(this).data('sectionId');
         const sectionRow = $('[data-section-id="' + sectionId + '"]');
+
+        // Disable the delete comfirmation button and append 
+        // processing indicator text to the confirm delete modal body.
+        $("#btnConfirmDelSection").prop('disabled', true);
+        $(".modal-body").append('<p>Processing... <i class="fa fa-spinner fa-spin" aria-hidden="true"></i></p>');
+
         $.ajax({
             url: removeUrl,
             type : "POST",
@@ -486,7 +492,8 @@ $(document).ready(function(){
             }
         })
         .always(function() {
-            $('#confirmDelSection').modal('hide');
+            $('#confirmDelSection').modal('hide');  // Re-enable the delete comfirmation button.
+            $("#btnConfirmDelSection").prop('disabled', false);
         });
     }
 

--- a/manage_sections/templates/manage_sections/create_section_form.html
+++ b/manage_sections/templates/manage_sections/create_section_form.html
@@ -1,8 +1,9 @@
 {% extends "icommons_ui/base_lti.html" %}
 {% load static %}
 {% block stylesheet %}
-{{ block.super }}
-{% endblock %}
+    {{ block.super }}
+    <link href="https://static.tlt.harvard.edu/shared/font-awesome-4.5.0/css/font-awesome.min.css" rel="stylesheet">
+{% endblock stylesheet %}
 
 {% block breadcrumb %}
 <nav>
@@ -106,7 +107,7 @@ $(document).ready(function(){
     // Add event listener to 'main-sis-section' elements to display a spinner upon click.
     $('.main-sis-section').on('click', function (event) {
         // Append loading content indicator after the clicked link.
-        $(this).parent('li').append('<span> Loadind... <i class="fa-li fa fa-spinner fa-spin"></i></span>');
+        $(this).parent('li').append(' Loading... <i class="fa fa-spinner fa-spin" aria-hidden="true"></i>');
     });
 
     //the sections menu

--- a/manage_sections/templates/manage_sections/section_details.html
+++ b/manage_sections/templates/manage_sections/section_details.html
@@ -2,8 +2,9 @@
 {% load static %}
 
 {% block stylesheet %}
-{{ block.super }}
-<link rel="stylesheet" type="text/css" href="{% static "manage_sections/css/manage_sections.css" %}" media="screen"/>
+    {{ block.super }}
+    <link href="https://static.tlt.harvard.edu/shared/font-awesome-4.5.0/css/font-awesome.min.css" rel="stylesheet">
+    <link rel="stylesheet" type="text/css" href="{% static "manage_sections/css/manage_sections.css" %}" media="screen"/>
 {% endblock stylesheet %}
 
 {% block breadcrumb %}
@@ -27,7 +28,7 @@
                 {% endif %}
                 
                 <div id="pane-left">
-                   {{section_name}}: <span class="enroll_count"></span> user<span class="enroll_count_pluralize"></span>
+                   {{section_name}}: <span class="enroll_count"><i class="fa fa-spinner fa-spin" aria-hidden="true"></i></span> user<span class="enroll_count_pluralize"></span>
                    <div id="sectionUsers">
                    </div>
                 </div>

--- a/manage_sections/templates/manage_sections/section_details.html
+++ b/manage_sections/templates/manage_sections/section_details.html
@@ -38,6 +38,9 @@
                         <button class="btn btn-primary pull-right add-selected-users" disabled><i class="fa fa-plus"></i> Add Selection</button>
                     {% endif %}
                     <div id="fullClassList">
+                        <div class="mt-5 pt-5">
+                            <br><span>Loading users... <span><i class="fa fa-spinner fa-spin" aria-hidden="true"></i>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/manage_sections/templates/manage_sections/section_list.html
+++ b/manage_sections/templates/manage_sections/section_list.html
@@ -8,14 +8,16 @@
         </a>
     {% endif %}
     </div>
-    <a class="listNav-item showSection" href="{% url 'manage_sections:section_details' section_id=section.id %}">
-        <span class="sectionName">{{ section.name }}</span>
-        {% if section.enrollment_count == 'n/a' %}
-            (enrollee count not available)
-        {% else %}
-            (<span class="sectionCount">{{section.enrollment_count}}</span> student{{ section.enrollment_count|pluralize }}<span style="font-size: larger;">*</span>)
-        {% endif %}
-    </a>
+    <div>
+        <a class="listNav-item showSection section-list" href="{% url 'manage_sections:section_details' section_id=section.id %}">
+            <span class="sectionName">{{ section.name }}</span>
+            {% if section.enrollment_count == 'n/a' %}
+                (enrollee count not available)
+            {% else %}
+                (<span class="sectionCount">{{section.enrollment_count}}</span> student{{ section.enrollment_count|pluralize }}<span style="font-size: larger;">*</span>)
+            {% endif %}
+        </a>
+    </div>
     <div class="editMenu">
     {% if section.registrar_section_flag %}
         <a href="#" class="disable-delete lti-tooltip" rel="tooltip" data-toggle="tooltip" title="You can't edit sections that have been created outside of Canvas" data-original-title="You can't edit sections that have been created outside of Canvas"><i class="fa fa-pencil"></i><span class="sr-only">Edit</span></a>


### PR DESCRIPTION
- Added loading content indicator (spinner) for when section links are clicked on to load enrollees in manage sections.
    - ![spinner gif](https://github.com/Harvard-University-iCommons/canvas_manage_course/assets/108423994/c8dbf8f6-0a2a-4606-b59b-4344df05ac14)
- Added loading content indicator (spinner) for when user clicks on `Add users to section` button.
    - ![add user gif](https://github.com/Harvard-University-iCommons/canvas_manage_course/assets/108423994/df5fc4ba-6513-48aa-8f7c-517759e9b39a)
- Added a processing indicator (spinner) and disabling the "Yes, delete" button while processing in progress.
    - ![delete modal gif](https://github.com/Harvard-University-iCommons/canvas_manage_course/assets/108423994/e2118a25-80a5-466f-870e-d12d1cf021e4)

- Added `DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'` in base settings file to fix warning about "Configure the DEFAULT_AUTO_FIELD setting"
- Added badges in README using https://shields.io/badges
    - Python static badge (will need to be updated manually)
    - Release tag dynamic badge (will dynamically update)
    - <img width="913" alt="badge image" src="https://github.com/Harvard-University-iCommons/canvas_manage_course/assets/108423994/6a655e7b-b512-4afb-811b-d842c45a6bdb">

Note:
- Released in DEV
- Test course [here](https://harvard.test.instructure.com/courses/111910/external_tools/100043). Another [course here](https://harvard.beta.instructure.com/courses/111487/external_tools/99868) with over 100 enrollees.