### PR TITLE
Task/idkjay/tlt 4549/manage sections update add section UI

### DIFF
--- a/manage_sections/templates/manage_sections/create_section_form.html
+++ b/manage_sections/templates/manage_sections/create_section_form.html
@@ -115,28 +115,34 @@ $(document).ready(function(){
         $('#newSectionName').focus();
     });
 
-    //listening to tab and enter. If the text input is empty then
-    //throw an error else continue adding the section
+    // Create a flag to track if 'insertSection' has been triggered
+    var insertSectionTriggered = false;
+
+    // Listening enter pressdown. If the text input is empty then
+    // throw an error else continue adding the section
     $('#newSectionName').bind('keydown', function(e){
-        //The jquery e.which property normalizes e.keyCode and e.charCode
-        //check for tab key (9), enter key (13) or esc key (27)
+        // The jquery e.which property normalizes e.keyCode and e.charCode
+        // Check for enter key (13) or esc key (27)
         switch(e.which){
-            case 9:
             case 13:
-                //check for empty input
+                // Check for empty input
                 if ($(this).val().length == 0){
                     $(this).parent().addClass('has-error');
-                    //change placeholder text to indicate error
+                    // Change placeholder text to indicate error
                     $('#newSectionName').attr('placeholder', 'You must provide a name');
-                    //keep focus on textbox
+                    // Keep focus on textbox
                     $(this).focus();
-                    //don't let them tab away
+                    // Don't let them tab away
                     e.preventDefault();
-
                     break;
                 }
-
-                $menu.trigger('insertSection');
+                
+                // Check if 'insertSection' has already been triggered
+                if (!insertSectionTriggered) {
+                    $menu.trigger('insertSection');
+                    insertSectionTriggered = true; // This will prevent multiple form submission
+                }
+                
                 e.preventDefault();
                 break;
             case 27:
@@ -144,9 +150,7 @@ $(document).ready(function(){
                 e.preventDefault();
                 break;
         }
-
     });
-
 
     //listen when the user has click away from the text input
     $(document).bind('click',function(e){
@@ -158,7 +162,7 @@ $(document).ready(function(){
                 //hide the form
                 $newSectionInput.trigger('toggle');
             } else if ($(e.target).hasClass('saveAdd')){
-                    e.preventDefault();
+                e.preventDefault();
                 // Check if the input field is empty
                 if ($('#newSectionName').val().length == 0) {
                     $('#newSectionName').parent().addClass('has-error');
@@ -166,8 +170,8 @@ $(document).ready(function(){
                 } else {
                     // Call AJAX method to insert a section
                     $menu.trigger('insertSection');
-            }
-        }
+                }
+            } 
         //checks to see if the update form is visible
         } else if (($('#editSection').hasClass('showSection'))) {
             //cancel the edit operation by hiding form and restoring

--- a/manage_sections/templates/manage_sections/create_section_form.html
+++ b/manage_sections/templates/manage_sections/create_section_form.html
@@ -47,6 +47,7 @@
             <label for="newSectionName" class="sr-only">Enter a section name</label>
             <input type="text" id="newSectionName" placeholder="Enter Section Name" class="form-control " />
             <span class="closeInput closeAdd cancelAdd"><i class="fa fa-times cancelAdd"></i></span>
+            <span class="closeInput closeAdd saveAdd"><i class="fa fa-floppy-o saveAdd"></i></span>
             <div id="formErr" class="hide">
                 <p class="text-danger">We've encountered an error creating the requested section. Please try again.</p>
             </div>
@@ -148,56 +149,43 @@ $(document).ready(function(){
 
 
     //listen when the user has click away from the text input
-    $(document).bind('mousedown',function(e){
+    $(document).bind('click',function(e){
         //checks to see the form input is visible
-        if ( !($newSectionInput.is(':hidden')) )
-        {
+        if (!($newSectionInput.is(':hidden'))) {
             //closing the input text field when clicking on the x
+            insertSectionTriggered = false;
             if ($(e.target).hasClass('cancelAdd')){
                 //hide the form
                 $newSectionInput.trigger('toggle');
-            }else{
-                //1 listens for mouse click and if the input is empty
-                //keep the input open with error class
-                //Else the user clicked after populating the text and inserts
-                //the new section
-                if ( e.which == 1 && $('#newSectionName').val().length == 0 ){
-                    //keep focus on textbox
+            } else if ($(e.target).hasClass('saveAdd')){
                     e.preventDefault();
-                    $newSectionInput.focus();
+                // Check if the input field is empty
+                if ($('#newSectionName').val().length == 0) {
                     $('#newSectionName').parent().addClass('has-error');
-                    //change placeholder text to indicate error
                     $('#newSectionName').attr('placeholder', 'You must provide a name');
-                }else{
-                    //call to AJAX method to insert a section
+                } else {
+                    // Call AJAX method to insert a section
                     $menu.trigger('insertSection');
-                }
             }
         }
         //checks to see if the update form is visible
-        else if ( ($('#editSection').hasClass('showSection')) )
-        {
+        } else if (($('#editSection').hasClass('showSection'))) {
             //cancel the edit operation by hiding form and restoring
             //to previous section name
-            if ( $(e.target).hasClass('cancelEdit') )
-                cancelEditing();
-
+            if ($(e.target).hasClass('cancelEdit')) cancelEditing();
             //1 listens for mouse click and if the input is empty
             //keep the input open with error class
             //Else the user clicked after populating the text and inserts
             //the new section
-            if ( e.which == 1 && $('#editSectionName').val().length == 0 ){
+            if (e.which == 1 && $('#editSectionName').val().length == 0) {
                 //keep focus on textbox
                 e.preventDefault();
                 $newSectionInput.focus();
                 $('#editSectionName').parent().addClass('has-error');
                 $('#editSectionName').attr('placeholder', 'You must provide a name');
-
-            }
             //allow them to click on the input field but once they click
             //outside then continue with the update
-            else if ( $(e.target).attr('id') != 'editSectionName' )
-            {
+            } else if ($(e.target).attr('id') != 'editSectionName') {
                 //hide the form after editing the section name
                 $editSectionForm.removeClass('showSection').addClass('hide');
                 //remove any error classes


### PR DESCRIPTION
- Added `Save` icon to form input of a new section, placed it next to the `Cancel` icon
![Add Section UI](https://github.com/Harvard-University-iCommons/canvas_manage_course/assets/49657701/16dbb912-729d-434b-848e-0d791823acfa)

- Removed the ability to save form input by clicking `Tab` or clicking outside of the form input box
- Fixed issue where clicking `Enter` in quick succession after filling out form input would submit that information multiple times and create duplicate sections

Notes:
- Deployed on `DEV`