### PR TITLE
Manage Sections should only allow people to be added from non-manual sections

### DIFF
--- a/manage_sections/utils.py
+++ b/manage_sections/utils.py
@@ -41,7 +41,11 @@ def unique_enrollments_not_in_section_filter(section_id, enrollments):
     section_set = {role_key(x) for x in enrollments if x['course_section_id'] == int(section_id)}
     # Use a temporary dictionary to get unique enrollments based on the "role_key".  Filter out any
     # records where the role_key is present in the current section (by using the section_set above)
-    return list({role_key(x): x for x in enrollments if role_key(x) not in section_set}.values())
+
+    # Filter out enrollments in manually-created sections (source='managecrs')
+    non_manual_enrollments = [enr for enr in enrollments if enr.get('source') != 'managecrs']
+
+    return list({role_key(x): x for x in non_manual_enrollments if role_key(x) not in section_set}.values())
 
 
 def get_section_by_id(section_id):

--- a/manage_sections/views.py
+++ b/manage_sections/views.py
@@ -380,17 +380,23 @@ def section_class_list(request, section_id):
     """
     canvas_course_id = request.LTI['custom_canvas_course_id']
     section = canvas_api_helper_sections.get_section(canvas_course_id, section_id)
+
+    # Fetch enrollments for the course
     course_enrollments = [
         e for e in canvas_api_helper_enrollments.get_enrollments(canvas_course_id)
         if e['type'] in ENROLLMENT_TYPES
     ]
 
+    # Apply the unique enrollment filter, ensuring non-manual enrollments are included
     eligible_enrollments = unique_enrollments_not_in_section_filter(
         section_id, course_enrollments)
+    
+    # Add badges and roles to the filtered enrollments
     enrollments_badged = _add_badge_label_name_to_enrollments(
         eligible_enrollments)
     enrollments = canvas_api_helper_enrollments.add_role_labels_to_enrollments(
         enrollments_badged)
+    
     enrollments.sort(key=lambda x: x['user']['sortable_name'])
 
     return render(request, 'manage_sections/_section_classlist.html', {


### PR DESCRIPTION
- Updated the `unique_enrollments_not_in_section_filter `method in `utils.py` to filter out enrollments in sections where the source is `managecrs`.
- Added comments to `section_class_list` view in `views.py` where the updated filtering logic is applied after fetching and displaying the list of eligible enrollments.

Deployed in `DEV`