### PR TITLE
Canvas Manage Course: Improve error messages displayed to end users

### DIFF
--- a/manage_people/templates/manage_people/add_user_confirmation.html
+++ b/manage_people/templates/manage_people/add_user_confirmation.html
@@ -26,7 +26,7 @@
                     <span class="label">HKL</span>
                 {% endif %}
                 <div class="float-right">
-                    {% elif existing_enrollment %}
+                    {% if existing_enrollment %}
                         <span class="text-strong"><i class="fa fa-check"></i> Already enrolled as a {{ enrollee.canvas_role_label }}</span>
                     {% else %}
                         <span class="text-strong text-success"><i class="fa fa-check"></i> Enrolled as a {{ enrollee.canvas_role_label }}</span>

--- a/manage_people/templates/manage_people/add_user_confirmation.html
+++ b/manage_people/templates/manage_people/add_user_confirmation.html
@@ -26,10 +26,6 @@
                     <span class="label">HKL</span>
                 {% endif %}
                 <div class="float-right">
-                    {% if enrollee.error_message %}
-                        <span class="text-strong text-danger">
-                            <i class="fa fa-exclamation-circle"></i> {{ enrollee.error_message }}
-                        </span>
                     {% elif existing_enrollment %}
                         <span class="text-strong"><i class="fa fa-check"></i> Already enrolled as a {{ enrollee.canvas_role_label }}</span>
                     {% else %}

--- a/manage_people/templates/manage_people/add_user_confirmation.html
+++ b/manage_people/templates/manage_people/add_user_confirmation.html
@@ -26,7 +26,11 @@
                     <span class="label">HKL</span>
                 {% endif %}
                 <div class="float-right">
-                    {% if existing_enrollment %}
+                    {% if enrollee.error_message %}
+                        <span class="text-strong text-danger">
+                            <i class="fa fa-exclamation-circle"></i> {{ enrollee.error_message }}
+                        </span>
+                    {% elif existing_enrollment %}
                         <span class="text-strong"><i class="fa fa-check"></i> Already enrolled as a {{ enrollee.canvas_role_label }}</span>
                     {% else %}
                         <span class="text-strong text-success"><i class="fa fa-check"></i> Enrolled as a {{ enrollee.canvas_role_label }}</span>

--- a/manage_people/templates/manage_people/base_new.html
+++ b/manage_people/templates/manage_people/base_new.html
@@ -28,7 +28,16 @@
         </div>
     {% else %}
         <main class="float-left col-60">
-          {% block page_content %}{% endblock page_content %}
+            {% if messages %}
+                <div class="alert-messages">
+                {% for message in messages %}
+                    <div class="alert alert-{{ message.tags }}">
+                    {{ message }}
+                    </div>
+                {% endfor %}
+                </div>
+            {% endif %}
+            {% block page_content %}{% endblock page_content %}
         </main>
         <aside class="float-left col-40 clearfix">
             <p>

--- a/manage_people/templates/manage_people/base_new.html
+++ b/manage_people/templates/manage_people/base_new.html
@@ -28,15 +28,6 @@
         </div>
     {% else %}
         <main class="float-left col-60">
-            {% if messages %}
-                <div class="alert-messages">
-                {% for message in messages %}
-                    <div class="alert alert-{{ message.tags }}">
-                    {{ message }}
-                    </div>
-                {% endfor %}
-                </div>
-            {% endif %}
             {% block page_content %}{% endblock page_content %}
         </main>
         <aside class="float-left col-40 clearfix">

--- a/manage_people/views.py
+++ b/manage_people/views.py
@@ -13,6 +13,7 @@ from canvas_sdk.methods import enrollments
 from canvas_sdk.utils import get_all_list_data
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
+from django.contrib import messages
 from django.db import IntegrityError
 from django.db.models import Q
 from django.http import HttpResponseRedirect, JsonResponse
@@ -331,13 +332,16 @@ def add_users(request):
             )
             person.error_message = None
         except EnrollmentError as e:
+            messages.error(
+                request,
+                f"[{e.user_id or user_id}] {e.message}"
+            )
             person = Person(
                 univ_id=e.user_id or user_id,
                 name_first='Unknown',
                 name_last='',
                 email_address=''
             )
-            person.error_message = e.message
             existing = False  
 
         enrollment_results.append((existing, person))

--- a/manage_people/views.py
+++ b/manage_people/views.py
@@ -325,20 +325,20 @@ def add_users(request):
     for user_id, user_role_id in list(users_to_add.items()):
         # Add the returned (existing_enrollment, person) tuple to the results
         # list
-        existing, person, error_msg = add_member_to_course(
-            user_id, int(user_role_id), course_instance_id, canvas_course_instance_id
-        )
-
-        if person: 
-            person.error_message = error_msg
-        else:
-            person = Person(
-                univ_id=user_id,
-                name_first='[Unknown]',
-                name_last='',
-                email_address='[unknown]'
+        try:
+            existing, person = add_member_to_course(
+                user_id, int(user_role_id), course_instance_id, canvas_course_instance_id
             )
-            error_message = error_message or f"Could not find a person record for user ID {user_id}. Ensure the user exists in the system."
+            person.error_message = None
+        except EnrollmentError as e:
+            person = Person(
+                univ_id=e.user_id or user_id,
+                name_first='Unknown',
+                name_last='',
+                email_address=''
+            )
+            person.error_message = e.message
+            existing = False  
 
         enrollment_results.append((existing, person))
 

--- a/manage_people/views.py
+++ b/manage_people/views.py
@@ -388,7 +388,7 @@ def add_member_to_course(user_id, user_role_id, course_instance_id,
         user_id=user_id,
         role_id=user_role_id,
         course_instance_id=course_instance_id,
-        source=None
+        source='managecrs'
     )
 
     logger.debug('Adding %s to %s table as user_role_id %s',
@@ -396,6 +396,7 @@ def add_member_to_course(user_id, user_role_id, course_instance_id,
 
     try:
         enrollment.save()
+        logger.info(f"Created enrollment for user {user_id} in course_instance_id {course_instance_id} as role_id {user_role_id}")
     except IntegrityError:
         existing_enrollment = True
         error_message = f"User {user_id} is already enrolled with the selected role."

--- a/manage_people/views.py
+++ b/manage_people/views.py
@@ -212,24 +212,20 @@ def get_enrolled_roles_for_user_ids(canvas_course_id, search_results_user_ids):
 
     found_ids = defaultdict(list)
     for enrollment in canvas_enrollments:
-        try:
-            enrollment_role = UserRole.objects.filter(canvas_role_id=enrollment['role_id']).first()
+        enrollment_role = UserRole.objects.filter(canvas_role_id=enrollment['role_id']).first()
 
-            sis_user_id = enrollment['user']['sis_user_id']
-            if sis_user_id in search_results_user_ids:
-                if enrollment_role:
-                    enrollment.update({'canvas_role_label': enrollment_role.role_name})
-                else: 
-                    logger.warning(f"No matching UserRole found for canvas_role_id {enrollment['role_id']}")
-                    enrollment.update({'canvas_role_label': f"Unknown role {enrollment['role_id']}"})
-                    error_messages.append(
-                        f"Unable to resolve a role for user {sis_user_id} (Canvas role id {enrollment['role_id']}). This may be due to an outdated or unrecognized role mapping."
-                    )
+        sis_user_id = enrollment['user']['sis_user_id']
+        if sis_user_id in search_results_user_ids:
+            if enrollment_role:
+                enrollment.update({'canvas_role_label': enrollment_role.role_name})
+            else: 
+                logger.warning(f"No matching UserRole found for canvas_role_id {enrollment['role_id']}")
+                enrollment.update({'canvas_role_label': f"Unknown role {enrollment['role_id']}"})
+                error_messages.append(
+                    f"Unable to resolve a role for user {sis_user_id} (Canvas role id {enrollment['role_id']}). This may be due to an outdated or unrecognized role mapping."
+                )
 
-                found_ids[sis_user_id].append(enrollment)
-        except UserRole.DoesNotExist:
-            logger.warning(f'Error: Canvas role id {enrollment["role_id"]} does not exist in the UserRole table.')
-            error_messages.append(f'One or more roles could not be retrieved for the user from the Canvas role list.')
+            found_ids[sis_user_id].append(enrollment)
 
     t3 = time.perf_counter()
     logger.debug(f'*** TIMING getting role labels took {t3 - t2} seconds')

--- a/manage_people/views.py
+++ b/manage_people/views.py
@@ -383,7 +383,6 @@ def add_member_to_course(user_id, user_role_id, course_instance_id,
     
     # get an instance of the correct Course* model class for this role
     model_class = get_course_member_class(user_role)
-    enrollment = model_class()
     enrollment = model_class(
         user_id=user_id,
         role_id=user_role_id,

--- a/manage_people/views.py
+++ b/manage_people/views.py
@@ -379,7 +379,7 @@ def add_member_to_course(user_id, user_role_id, course_instance_id,
     user_role = get_user_role_if_permitted(course_instance_id, user_role_id)
     if user_role is None:
         error_message = f"The selected role (ID {user_role_id}) is not permitted for this course."
-        return False, None, error_message
+        raise EnrollmentError(error_message, user_id)
     
     # get an instance of the correct Course* model class for this role
     model_class = get_course_member_class(user_role)
@@ -447,7 +447,7 @@ def add_member_to_course(user_id, user_role_id, course_instance_id,
             error_message = f"Canvas enrollment failed for user {user_id}: {str(e)}"
             logger.exception(error_message)
 
-    return existing_enrollment, person, error_message
+    return existing_enrollment, person
 
 def get_enrollments_added_through_tool(sis_course_id):
     """

--- a/manage_people/views.py
+++ b/manage_people/views.py
@@ -407,13 +407,12 @@ def add_member_to_course(user_id, user_role_id, course_instance_id,
 
     # Get user details for confirmation
     person = Person.objects.filter(univ_id=user_id).first()
-    if person:
-        person.badge_label = get_badge_label_name(person.role_type_cd)
-        person.role_id = user_role.role_id
-        person.role_name = user_role.role_name
-    else:
-        error_message = error_message or f"Person record not found for user_id {user_id}."
-        return existing_enrollment, None, error_message
+    if not person:
+        raise EnrollmentError(f"Person record not found for user_id {user_id}.", user_id)
+
+    person.badge_label = get_badge_label_name(person.role_type_cd)
+    person.role_id = user_role.role_id
+    person.role_name = user_role.role_name
 
     # create the canvas enrollment if needed.  add enrollee to primary section
     # if it exists, otherwise add to the course.

--- a/manage_people/views.py
+++ b/manage_people/views.py
@@ -48,6 +48,13 @@ logger = logging.getLogger(__name__)
 audit_logger = logging.getLogger('manage_people_audit_log')
 pp = pprint.PrettyPrinter(indent=4)
 
+class EnrollmentError(Exception):
+    """Custom exception raised when a user enrollment fails."""
+    def __init__(self, message, user_id=None):
+        self.message = message
+        self.user_id = user_id
+        super().__init__(self.message)
+
 
 @login_required
 @require_http_methods(['GET'])

--- a/manage_people/views.py
+++ b/manage_people/views.py
@@ -396,7 +396,14 @@ def add_member_to_course(user_id, user_role_id, course_instance_id,
     except IntegrityError:
         existing_enrollment = True
         error_message = f"User {user_id} is already enrolled with the selected role."
-        logger.warning(error_message)
+        logger.warning(
+            error_message, 
+            extra={
+                "user_id": user_id,
+                "course_instance_id": course_instance_id,
+                "user_role_id": user_role_id,
+            }
+        )
     except RuntimeError as e:
         existing_enrollment = True
         error_message = f"Unexpected error while saving enrollment for user {user_id}: {str(e)}"
@@ -442,7 +449,14 @@ def add_member_to_course(user_id, user_role_id, course_instance_id,
                 logger.warning(error_message)
         except Exception as e:
             error_message = f"Canvas enrollment failed for user {user_id}: {str(e)}"
-            logger.exception(error_message)
+            logger.exception(
+                error_message,
+                extra={
+                    "user_id": user_id,
+                    "course_instance_id": course_instance_id,
+                    "canvas_course_id": canvas_course_id,
+                }
+            )
 
     return existing_enrollment, person
 

--- a/manage_people/views.py
+++ b/manage_people/views.py
@@ -331,20 +331,13 @@ def add_users(request):
                 user_id, int(user_role_id), course_instance_id, canvas_course_instance_id
             )
             person.error_message = None
+            enrollment_results.append((existing, person))
         except EnrollmentError as e:
             messages.error(
                 request,
-                f"[{e.user_id or user_id}] {e.message}"
+                f"[User: {e.user_id or user_id}]: {e.message}"
             )
-            person = Person(
-                univ_id=e.user_id or user_id,
-                name_first='Unknown',
-                name_last='',
-                email_address=''
-            )
-            existing = False  
-
-        enrollment_results.append((existing, person))
+            return HttpResponseRedirect(reverse('manage_people:find_user'))
 
     # get the updated (or cached) Canvas role list so we can show the right
     # role labels for these enrollments
@@ -362,7 +355,7 @@ def add_users(request):
 
     # annotate enrollments with the Canvas role label
     for (_, person) in enrollment_results:
-        person.canvas_role_label = labels_by_user_role_id.get(person.role_id)
+        person.canvas_role_label = labels_by_user_role_id.get(person.role_id, 'Unknown')
 
     return render(request, 'manage_people/add_user_confirmation.html', {
         'workflow_state': workflow_state,


### PR DESCRIPTION
Improved level of detail included in error messages displayed to users. Added more potential error messages.
It logs the error to django messages.
It redirects the user back to the find_user page screen .

Error message: already enrolled with the selected role
<img width="493" alt="image" src="https://github.com/user-attachments/assets/e8605c6d-197e-4ea6-bc48-9ebdc5350193" />

When attempting to add a user that has already been added:
<img width="513" alt="image" src="https://github.com/user-attachments/assets/c4c82cb4-535e-490a-a756-38e72fe9b794" />

