### PR TITLE
Handle Harvard Guest NetID format

### DIFF
--- a/manage_people/views.py
+++ b/manage_people/views.py
@@ -12,8 +12,8 @@ from canvas_sdk.exceptions import CanvasAPIError
 from canvas_sdk.methods import enrollments
 from canvas_sdk.utils import get_all_list_data
 from django.conf import settings
-from django.contrib.auth.decorators import login_required
 from django.contrib import messages
+from django.contrib.auth.decorators import login_required
 from django.db import IntegrityError
 from django.db.models import Q
 from django.http import HttpResponseRedirect, JsonResponse
@@ -219,7 +219,7 @@ def get_enrolled_roles_for_user_ids(canvas_course_id, search_results_user_ids):
         if sis_user_id in search_results_user_ids:
             if enrollment_role:
                 enrollment.update({'canvas_role_label': enrollment_role.role_name})
-            else: 
+            else:
                 logger.warning(f"No matching UserRole found for canvas_role_id {enrollment['role_id']}")
                 enrollment.update({'canvas_role_label': f"Unknown role {enrollment['role_id']}"})
                 error_messages.append(
@@ -377,7 +377,7 @@ def add_member_to_course(user_id, user_role_id, course_instance_id,
     if user_role is None:
         error_message = f"The selected role (ID {user_role_id}) is not permitted for this course."
         raise EnrollmentError(error_message, user_id)
-    
+
     # get an instance of the correct Course* model class for this role
     model_class = get_course_member_class(user_role)
     enrollment = model_class(
@@ -397,7 +397,7 @@ def add_member_to_course(user_id, user_role_id, course_instance_id,
         existing_enrollment = True
         error_message = f"User {user_id} is already enrolled with the selected role."
         logger.warning(
-            error_message, 
+            error_message,
             extra={
                 "user_id": user_id,
                 "course_instance_id": course_instance_id,
@@ -438,7 +438,7 @@ def add_member_to_course(user_id, user_role_id, course_instance_id,
         #       in the future.
         canvas_role_name = get_canvas_role_name(user_role_id)
         canvas_section = get_canvas_course_section(course_instance_id)
-        try: 
+        try:
             if canvas_section:
                 canvas_enrollment = add_canvas_section_enrollee(
                     canvas_section['id'], canvas_role_name, user_id, enrollment_role_id=user_role.canvas_role_id)
@@ -764,8 +764,8 @@ def lti_key_error_response(request, key_error_exception):
 
 
 def _get_people_in_list_query(user_id_list=[]):
-    pat = re.compile(r'[^\w]+', re.UNICODE)
-    clean_user_ids = ["'{}'".format(pat.sub('', i)) for i in user_id_list if len(pat.sub('', i)) == 8]
+    pat = re.compile(r'[^\w-]+', re.UNICODE)
+    clean_user_ids = ["'{}'".format(pat.sub('', i)) for i in user_id_list if len(pat.sub('', i)) <= 10]
     if clean_user_ids:
         # split clean_user_ids into chunks of 999 (https://www.geeksforgeeks.org/break-list-chunks-size-n-python/)
         n = 999

--- a/manage_sections/views.py
+++ b/manage_sections/views.py
@@ -390,13 +390,13 @@ def section_class_list(request, section_id):
     # Apply the unique enrollment filter, ensuring non-manual enrollments are included
     eligible_enrollments = unique_enrollments_not_in_section_filter(
         section_id, course_enrollments)
-    
+
     # Add badges and roles to the filtered enrollments
     enrollments_badged = _add_badge_label_name_to_enrollments(
         eligible_enrollments)
     enrollments = canvas_api_helper_enrollments.add_role_labels_to_enrollments(
         enrollments_badged)
-    
+
     enrollments.sort(key=lambda x: x['user']['sortable_name'])
 
     return render(request, 'manage_sections/_section_classlist.html', {
@@ -558,8 +558,8 @@ def remove_from_section(request):
 
 
 def _get_people_in_list_query(user_id_list=[]):
-    pat = re.compile('[^\w]+', re.UNICODE)
-    clean_user_ids = ["'{}'".format(pat.sub('', i)) for i in user_id_list if len(pat.sub('', i)) == 8]
+    pat = re.compile(r'[^\w-]+', re.UNICODE)
+    clean_user_ids = ["'{}'".format(pat.sub('', i)) for i in user_id_list if len(pat.sub('', i)) <= 10]
     if clean_user_ids:
         # split clean_user_ids into chunks of 999 (https://www.geeksforgeeks.org/break-list-chunks-size-n-python/)
         n = 999


### PR DESCRIPTION
## Summary

Handles a bug where (in some cases) Manage People would fail to load when a user with the new Harvard Guest NetID (e.g. `hg-0000000`) was enrolled in the course, showing a 500 error to the user.

This update refactors the regular expression in `_get_people_in_list_query` to include dashes and allow IDs greater than 8 characters. Now, `clean_user_ids` can contain both HUIDs and Harvard Guest NetIDs for use in the subsequent database query to `people.v_huid_and_xid_people`.

## 500 Error Scenario

When the Manage People list for a course contains just a single user, and that user has a Harvard Guest NetID, that ID gets filtered out of `clean_user_ids`. This means that there will then be zero results in `clean_user_ids`, resulting in a faulty query to `people.v_huid_and_xid_people`. This leads to a 500 error for the end user.

OLD: 500 error

UPDATED:
<img width="682" height="262" alt="Screenshot 2025-09-10 at 10 55 42 AM" src="https://github.com/user-attachments/assets/32afb360-603c-48c6-94fb-37e571f29dd6" />

## Other non-500 Issue

If the Manage People list contains at least one HUID in addition to the problematic Harvard Guest NetID, then `clean_user_ids` will be populated and the DB query will proceed as normal. However, the Harvard Guest NetID users are not included in that query, and the tool is therefore unable to identify their role type. For the end user, the means that those Harvard Guest NetID users will have an "Other" designation for their badge.

OLD: 
<img width="706" height="482" alt="Screenshot 2025-09-10 at 10 49 42 AM" src="https://github.com/user-attachments/assets/da723599-506b-4a19-9ed2-b25ecf1859c8" />

UPDATED:
<img width="668" height="413" alt="Screenshot 2025-09-10 at 10 54 35 AM" src="https://github.com/user-attachments/assets/d6d6942c-a2d9-4ef9-a632-1ec52ad21177" />
