### PR TITLE
Add deprecation notice banner to Manage Course dashboard

### DIFF
--- a/canvas_manage_course/templates/canvas_manage_course/banner.html
+++ b/canvas_manage_course/templates/canvas_manage_course/banner.html
@@ -35,7 +35,7 @@
         Please review the documentation and provide feedback on the transition.
     </p>
     <div class="notice-buttons">
-        <a href="https://harvard.az1.qualtrics.com/jfe/form/SV_9zPVqdU3GyMJJeC" class="btn btn-sm btn-warning" target="_blank">
+        <a href="https://qualtrics-auth.tlt.harvard.edu/a/caf3e373-fa57-4db7-b9cd-e49a13431bc0" class="btn btn-sm btn-warning" target="_blank">
             <i class="fa fa-comment"></i> Provide Feedback
         </a>
         <a href="https://harvard.service-now.com/ithelp?id=kb_article&sys_id=ffbaa295377d76c09aa163d2b3990ee6" class="btn btn-sm btn-info" target="_blank">

--- a/canvas_manage_course/templates/canvas_manage_course/banner.html
+++ b/canvas_manage_course/templates/canvas_manage_course/banner.html
@@ -31,7 +31,7 @@
 <div class="deprecation-notice">
     <h4><i class="fa fa-exclamation-triangle"></i> Important: Tool Deprecation Notice</h4>
     <p>
-        This Course Manager is being deprecated and will be replaced by the new <strong>Manage Course [New!]</strong>.
+        This Manage Course tool is being deprecated and will be replaced by the new <strong>Manage Course [New!]</strong>.
         Please review the documentation and provide feedback on the transition.
     </p>
     <div class="notice-buttons">

--- a/canvas_manage_course/templates/canvas_manage_course/banner.html
+++ b/canvas_manage_course/templates/canvas_manage_course/banner.html
@@ -1,0 +1,45 @@
+{% comment %} CSS for the deprecation notice banner {% endcomment %}
+<style>
+    .deprecation-notice {
+        background-color: #fff3cd;
+        border-left: 5px solid #ffc107;
+        margin-bottom: 20px;
+        padding: 16px 20px;
+        border-radius: 4px;
+    }
+    .deprecation-notice h4 {
+        color: #856404;
+        margin-top: 0;
+        margin-bottom: 8px;
+    }
+    .deprecation-notice h4 i {
+        margin-right: 6px;
+    }
+    .deprecation-notice p {
+        margin-bottom: 12px;
+    }
+    .notice-buttons a {
+        margin-right: 10px;
+        display: inline-block;
+    }
+    .notice-buttons a i {
+        margin-right: 4px;
+    }
+</style>
+
+{% comment %} HTML for the deprecation notice banner {% endcomment %}
+<div class="deprecation-notice">
+    <h4><i class="fa fa-exclamation-triangle"></i> Important: Tool Deprecation Notice</h4>
+    <p>
+        This Course Manager is being deprecated and will be replaced by the new <strong>Manage Course [New!]</strong>.
+        Please review the documentation and provide feedback on the transition.
+    </p>
+    <div class="notice-buttons">
+        <a href="https://harvard.az1.qualtrics.com/jfe/form/SV_9zPVqdU3GyMJJeC" class="btn btn-sm btn-warning" target="_blank">
+            <i class="fa fa-comment"></i> Provide Feedback
+        </a>
+        <a href="https://harvard.service-now.com/ithelp?id=kb_article&sys_id=ffbaa295377d76c09aa163d2b3990ee6" class="btn btn-sm btn-info" target="_blank">
+            <i class="fa fa-book"></i> View Documentation
+        </a>
+    </div>
+</div>

--- a/canvas_manage_course/templates/canvas_manage_course/dashboard_course.html
+++ b/canvas_manage_course/templates/canvas_manage_course/dashboard_course.html
@@ -17,6 +17,8 @@
   <h3>
     Manage Course
   </h3>
+
+  {% include "canvas_manage_course/banner.html" %}
 </nav>
 {% endblock dashboard_breadcrumb %}
 


### PR DESCRIPTION
Adds a deprecation notice banner to inform users that the Manage Course is being deprecated and will be replaced by the new **Manage Course [New!]**.
- Includes a button that links to a Qualtrics survey to gather user feedback.
- Includes a button that links to documentation for the Manage Course Tool.

Deployed in DEV ([test course here](https://harvard.beta.instructure.com/courses/160424/external_tools/17079))

Screenshot of banner:
<img width="1113" height="420" alt="Screenshot 2026-03-11 at 16 58 30" src="https://github.com/user-attachments/assets/5ab0585c-f9f5-41ce-8807-53dc14221f63" />
